### PR TITLE
Adds the onpush hook into the server.

### DIFF
--- a/rs-backend/src/handler.rs
+++ b/rs-backend/src/handler.rs
@@ -1,0 +1,64 @@
+//! Boilerplate for parsing and responding to both GET and POST requests.
+
+use std::ops::Deref;
+use std::io::Read;
+
+use serde;
+use serde_json::{self, Value};
+use iron::prelude::*;
+use iron::status;
+use persistent::State;
+
+use load::InputData;
+use errors::*;
+
+pub fn respond(res: Result<Value>) -> IronResult<Response> {
+    use iron::headers::{ContentType, AccessControlAllowOrigin};
+    use iron::mime::{Mime, TopLevel, SubLevel};
+    use iron::modifiers::Header;
+
+    let mut resp = match res {
+        Ok(json) => {
+            let mut resp = Response::with((status::Ok, serde_json::to_string(&json).unwrap()));
+            resp.set_mut(Header(ContentType(Mime(TopLevel::Application, SubLevel::Json, vec![]))));
+            resp
+        },
+        Err(err) => {
+            // TODO: Print to stderr
+            println!("An error occurred: {:?}", err);
+            Response::with((status::InternalServerError, err.to_string()))
+        }
+    };
+    resp.set_mut(Header(AccessControlAllowOrigin::Any));
+    Ok(resp)
+}
+
+pub trait PostHandler: Sized {
+    fn handle(_body: Self, _data: &InputData) -> Result<Value>;
+
+    fn handler(req: &mut Request) -> IronResult<Response>
+        where Self: serde::Deserialize {
+
+        let rwlock = req.get::<State<InputData>>().unwrap();
+        let data = rwlock.read().unwrap();
+
+        let mut buf = String::new();
+        let res = match req.body.read_to_string(&mut buf).unwrap() {
+            0 => Err("POST handler with 0 length body.".into()),
+            _ => Self::handle(serde_json::from_str(&buf).unwrap(), data.deref())
+        };
+
+        respond(res)
+    }
+}
+
+pub trait GetHandler: Sized {
+    fn handle(_data: &InputData) -> Result<Value>;
+
+    fn handler(req: &mut Request) -> IronResult<Response> {
+        let rwlock = req.get::<State<InputData>>().unwrap();
+        let data = rwlock.read().unwrap();
+
+        respond(Self::handle(data.deref()))
+    }
+}

--- a/rs-backend/src/main.rs
+++ b/rs-backend/src/main.rs
@@ -12,7 +12,7 @@ extern crate serde_json;
 
 pub const SERVER_ADDRESS: &'static str = "0.0.0.0:2346";
 
-mod handler;
+mod route_handler;
 mod util;
 mod load;
 mod server;

--- a/rs-backend/src/main.rs
+++ b/rs-backend/src/main.rs
@@ -12,6 +12,7 @@ extern crate serde_json;
 
 pub const SERVER_ADDRESS: &'static str = "0.0.0.0:2346";
 
+mod handler;
 mod util;
 mod load;
 mod server;

--- a/rs-backend/src/route_handler.rs
+++ b/rs-backend/src/route_handler.rs
@@ -12,11 +12,11 @@ use persistent::State;
 use load::InputData;
 use errors::*;
 
-pub fn respond(res: Result<Value>) -> IronResult<Response> {
-    use iron::headers::{ContentType, AccessControlAllowOrigin};
-    use iron::mime::{Mime, TopLevel, SubLevel};
-    use iron::modifiers::Header;
+use iron::headers::{ContentType, AccessControlAllowOrigin};
+use iron::mime::{Mime, TopLevel, SubLevel};
+use iron::modifiers::Header;
 
+pub fn respond(res: Result<Value>) -> IronResult<Response> {
     let mut resp = match res {
         Ok(json) => {
             let mut resp = Response::with((status::Ok, serde_json::to_string(&json).unwrap()));

--- a/rs-backend/src/server.rs
+++ b/rs-backend/src/server.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::cmp::max;
 
-use iron::{Iron, Chain};
+use iron::prelude::*;
 use router::Router;
 use persistent::State;
 use chrono::{Duration, NaiveDate, NaiveDateTime};
@@ -12,77 +12,11 @@ use serde;
 use SERVER_ADDRESS;
 use errors::*;
 use load::{SummarizedWeek, Kind, TestRun, InputData, Timing};
+use handler::{self, PostHandler, GetHandler};
 use util::{start_idx, end_idx};
+use git;
 
 const JS_DATE_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S.000Z";
-
-// Boilerplate for parsing and responding to both GET and POST requests.
-mod handler {
-    use std::ops::Deref;
-    use std::io::Read;
-
-    use serde;
-    use serde_json::{self, Value};
-    use iron::prelude::*;
-    use iron::status;
-    use persistent::State;
-
-    use load::InputData;
-    use errors::*;
-
-    fn respond(res: Result<Value>) -> IronResult<Response> {
-        use iron::headers::{ContentType, AccessControlAllowOrigin};
-        use iron::mime::{Mime, TopLevel, SubLevel};
-        use iron::modifiers::Header;
-
-        let mut resp = match res {
-            Ok(json) => {
-                let mut resp = Response::with((status::Ok, serde_json::to_string(&json).unwrap()));
-                resp.set_mut(Header(ContentType(Mime(TopLevel::Application, SubLevel::Json, vec![]))));
-                resp
-            },
-            Err(err) => {
-                // TODO: Print to stderr
-                println!("An error occurred: {:?}", err);
-                Response::with((status::InternalServerError, err.to_string()))
-            }
-        };
-        resp.set_mut(Header(AccessControlAllowOrigin::Any));
-        Ok(resp)
-    }
-
-    pub trait PostHandler: Sized {
-        fn handle(_body: Self, _data: &InputData) -> Result<Value>;
-
-        fn handler(req: &mut Request) -> IronResult<Response>
-            where Self: serde::Deserialize {
-
-            let rwlock = req.get::<State<InputData>>().unwrap();
-            let data = rwlock.read().unwrap();
-
-            let mut buf = String::new();
-            let res = match req.body.read_to_string(&mut buf).unwrap() {
-                0 => Err("POST handler with 0 length body.".into()),
-                _ => Self::handle(serde_json::from_str(&buf).unwrap(), data.deref())
-            };
-
-            respond(res)
-        }
-    }
-
-    pub trait GetHandler: Sized {
-        fn handle(_data: &InputData) -> Result<Value>;
-
-        fn handler(req: &mut Request) -> IronResult<Response> {
-            let rwlock = req.get::<State<InputData>>().unwrap();
-            let data = rwlock.read().unwrap();
-
-            respond(Self::handle(data.deref()))
-        }
-    }
-}
-
-use self::handler::{PostHandler, GetHandler};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum GroupBy {
@@ -522,6 +456,30 @@ fn mk_stats(data: &[&TestRun], crate_name: &str, phases: &[String]) -> Value {
         .build()
 }
 
+fn on_push(req: &mut Request) -> IronResult<Response> {
+    // FIXME we are throwing everything away and starting again. It would be
+    // better to read just the added files. These should be available in the
+    // body of the request.
+
+    println!("received onpush hook");
+
+    let mut responder = move || {
+        git::update_repo(git::get_repo_path()?)?;
+
+        println!("updating from filesystem...");
+        let new_data = InputData::from_fs()?;
+
+        let rwlock = req.get::<State<InputData>>().unwrap();
+        let mut data = rwlock.write().unwrap();
+
+        *data = new_data;
+
+        Ok(Value::String("Successfully updated from filesystem".to_owned()))
+    };
+
+    handler::respond(responder())
+}
+
 pub fn start(data: InputData) {
     let mut router = Router::new();
 
@@ -531,6 +489,7 @@ pub fn start(data: InputData) {
     router.post("/get_tabular", Tabular::handler);
     router.post("/get", Days::handler);
     router.post("/stats", Stats::handler);
+    router.post("/onpush", on_push);
 
     let mut chain = Chain::new(router);
     chain.link(State::<InputData>::both(data));


### PR DESCRIPTION
Implemented via pulling from GitHub, then reading all data from the
filesystem, and subsequently write-locking the data store, and updating
it. Locking the data store for as minimal a time as possible was the
primary intent; this should cause minimal downtime for users (since the
data store should only be write locked for a short time).

I'm not entirely happy with the clear everything out and reload, but wondering if it's worth working on changing that right now. Let me know if that's something we want implemented before this can move forward.

This also moves handler into its own file but that isn't directly related to the changes here; I can revert that change if needed.