### PR TITLE
Remove trailing whitespace in the HTML and JS files.

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -8,7 +8,7 @@
     <div>&gt;  <a href="graphs.html">graphs</a>, <a href="stats.html">stats</a>, comparisons, <a href="mem.html">memory graph</a>, <a href="table.html">table view</a>.</div>
     <div>
         <br><input type="radio" name="kind" checked="true" value="benchmarks">benchmarks<br>
-        <input type="radio" name="kind" value="rustc">bootstrap        
+        <input type="radio" name="kind" value="rustc">bootstrap
     </div>
     <div id="loading" style="display: none">loading...</div>
     <div id="content" style="display: none"></div>

--- a/graphs.html
+++ b/graphs.html
@@ -8,7 +8,7 @@
     <div>&gt;  graphs, <a href="stats.html">stats</a>, <a href="compare.html">comparisons</a>, <a href="mem.html">memory graph</a>, <a href="table.html">table view</a>.</div>
     <div>
         <br><input type="radio" name="kind" checked="true" value="benchmarks">benchmarks<br>
-        <input type="radio" name="kind" value="rustc">bootstrap        
+        <input type="radio" name="kind" value="rustc">bootstrap
     </div>
     <div id="loading">loading...</div>
     <canvas id="graph" width="1000" height="600" style="display: none">

--- a/mem.html
+++ b/mem.html
@@ -8,7 +8,7 @@
     <div>&gt; <a href="graphs.html">graphs</a>, <a href="stats.html">stats</a>, <a href="compare.html">comparisons</a>, memory graph, <a href="table.html">table view</a>.</div>
     <div>
         <br><input type="radio" name="kind" checked="true" value="benchmarks">benchmarks<br>
-        <input type="radio" name="kind" value="rustc">bootstrap        
+        <input type="radio" name="kind" value="rustc">bootstrap
     </div>
     <div id="loading">loading...</div>
     <canvas id="graph" width="1000" height="600" style="display: none">

--- a/shared.js
+++ b/shared.js
@@ -139,7 +139,7 @@ function make_settings(callback, total_label) {
         document.getElementById("settings").innerHTML = "Error fetching info";
         console.log("Error fetching info:");
         console.log(err);
-    });        
+    });
 }
 
 function truncate_name(name) {

--- a/stats.html
+++ b/stats.html
@@ -8,7 +8,7 @@
     <div>&gt;  <a href="graphs.html">graphs</a>, stats, <a href="compare.html">comparisons</a>, <a href="mem.html">memory graph</a>, <a href="table.html">table view</a>.</div>
     <div>
         <br><input type="radio" name="kind" checked="true" value="benchmarks">benchmarks<br>
-        <input type="radio" name="kind" value="rustc">bootstrap        
+        <input type="radio" name="kind" value="rustc">bootstrap
     </div>
     <div id="loading" style="display: none">loading...</div>
     <div id="content" style="display: none"></div>

--- a/table.html
+++ b/table.html
@@ -8,7 +8,7 @@
     <div>&gt;  <a href="graphs.html">graphs</a>, <a href="stats.html">stats</a>, <a href="compare.html">comparisons</a>, <a href="mem.html">memory graph</a>, table view.</div>
     <div>
         <br><input type="radio" name="kind" checked="true" value="benchmarks">benchmarks<br>
-        <input type="radio" name="kind" value="rustc">bootstrap        
+        <input type="radio" name="kind" value="rustc">bootstrap
     </div>
     <div id="settings">
         <span id="dates" class="settings">


### PR DESCRIPTION
This is done to aid possible future edits (since they may accidentally introduce these unrelated changes).