### PR TITLE
Declare structs for entire API in api.rs.

### DIFF
--- a/rs-backend/src/api.rs
+++ b/rs-backend/src/api.rs
@@ -1,0 +1,212 @@
+// Copyright 2016 The rustc-perf Project Developers. See the COPYRIGHT
+// file at the top-level directory.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Each API endpoint has its own module. The modules contain Request and/or
+//! Response structs; these contain the specifications for how to interact
+//! with the API.
+//!
+//! The responses are calculated in the server.rs file.
+
+pub mod summary {
+    use std::collections::HashMap;
+    use serde::{self, Serialize, Deserialize};
+
+    /// One decimal place rounded percent
+    #[derive(Debug, Copy, Clone)]
+    pub struct Percent(pub f64);
+
+    impl Deserialize for Percent {
+        fn deserialize<D>(deserializer: &mut D) -> ::std::result::Result<Percent, D::Error>
+            where D: serde::de::Deserializer
+        {
+            struct PercentVisitor;
+
+            impl serde::de::Visitor for PercentVisitor {
+                type Value = Percent;
+
+                fn visit_str<E>(&mut self, value: &str) -> ::std::result::Result<Percent, E>
+                    where E: serde::de::Error
+                {
+                    match value.parse() {
+                        Ok(value) => Ok(Percent(value)),
+                        Err(_) => Err(serde::de::Error::invalid_value(value)),
+                    }
+                }
+            }
+
+            deserializer.deserialize(PercentVisitor)
+        }
+    }
+
+    impl Serialize for Percent {
+        fn serialize<S>(&self, serializer: &mut S) -> ::std::result::Result<(), S::Error>
+            where S: serde::ser::Serializer
+        {
+            serializer.serialize_str(&format!("{:.1}", self.0))
+        }
+    }
+
+    // TODO: Deduplicate bootstrap counting for twice as much text; rephrase.
+    // TODO: Deduplicate 'First week in vector is the current week'.
+    // TODO: Come up with, document, and use terminology for referring to 13
+    //       weeks ago and 0 weeks ago.
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Response {
+        /// The average summary across all benchmarks and bootstrap.
+        /// Bootstrap counts for twice as much that all other benchmarks do.
+        pub total_summary: Percent,
+
+        /// By-crate (benchmark and bootstrap) comparisons of 0th week (13
+        /// weeks ago) and current week.
+        ///
+        /// Represented as a hashmap of crate names to percents.
+        pub total_breakdown: HashMap<String, Percent>,
+
+        /// 12 week long mapping of crate names to percent differences from
+        /// last week's times to the current week's times.
+        /// First week in vector is the current week.
+        pub breakdown: Vec<HashMap<String, Percent>>,
+
+        /// 12 week long averages across both benchmarks and bootstrap.
+        /// Bootstrap counts for twice as much that all other benchmarks do.
+        /// First week in vector is the current week.
+        pub summaries: Vec<Percent>,
+
+        /// 12 week long list of dates from which data was used for that week.
+        /// First week in vector is the current week.
+        pub dates: Vec<String>,
+    }
+}
+
+pub mod info {
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Response {
+        /// Sorted vector of crate names (benchmarks and all crates in the rust distribution)
+        pub crates: Vec<String>,
+
+        /// Sorted vector of phase names.
+        pub phases: Vec<String>,
+
+        /// Sorted vector of benchmark names.
+        pub benchmarks: Vec<String>,
+    }
+}
+
+pub mod data {
+    use serde_json::Value;
+
+    use load::Kind;
+    use server::{GroupBy, OptionalDate};
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Request {
+        #[serde(rename="start")]
+        pub start_date: OptionalDate,
+
+        #[serde(rename="end")]
+        pub end_date: OptionalDate,
+        pub kind: Kind,
+        pub group_by: GroupBy,
+
+        /// Which crates to return data for
+        pub crates: Vec<String>,
+
+        /// Which phases to return data for
+        pub phases: Vec<String>,
+    }
+
+    /// The response consists of a list of objects, from oldest to newest,
+    /// with these fields:
+    ///   - commit: Git commit hash of the compiler these results were obtained with.
+    ///   - date: The date of this run; in the JS_DATE_FORMAT (TODO: Link/reference)
+    ///   - data: An object with keys being the requested crates/phases (depending on group_by);
+    ///       - rss: u64 of memory usage (TODO: What unit? MB?)
+    ///       - time: f64 of duration for compiling (TODO: Is this in seconds?)
+    // TODO: Use a struct instead of Value.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Response(pub Vec<Value>);
+}
+
+pub mod tabular {
+    use std::collections::HashMap;
+
+    use load::{Kind, Timing};
+    use server::OptionalDate;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Request {
+        pub kind: Kind,
+        pub date: OptionalDate,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Response {
+        pub commit: String,
+
+        /// Mapping of all crates timed on this date to their timings by phase
+        pub data: HashMap<String, HashMap<String, Timing>>,
+        pub date: String,
+    }
+}
+
+pub mod days {
+    use serde_json::Value;
+
+    use load::Kind;
+    use server::{OptionalDate, GroupBy};
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Request {
+        pub kind: Kind,
+        pub group_by: GroupBy,
+        pub dates: Vec<OptionalDate>,
+
+        /// Which crates to return data for
+        pub crates: Vec<String>,
+
+        /// Which phases to return data for
+        pub phases: Vec<String>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Response(pub Vec<Value>);
+}
+
+pub mod stats {
+    use serde_json::Value;
+
+    use load::Kind;
+    use server::OptionalDate;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Request {
+        pub kind: Kind,
+        #[serde(rename="start")]
+        pub start_date: OptionalDate,
+        #[serde(rename="end")]
+        pub end_date: OptionalDate,
+
+        /// Which crates to return data for
+        /// kind rustc only: crate or phase can be 'total' (TODO: Better wording)
+        pub crates: Vec<String>,
+
+        /// Which phases to return data for
+        pub phases: Vec<String>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Response {
+        #[serde(rename="startDate")]
+        pub start_date: String,
+        #[serde(rename="endDate")]
+        pub end_date: String,
+        pub crates: Value,
+    }
+}

--- a/rs-backend/src/api.rs
+++ b/rs-backend/src/api.rs
@@ -17,6 +17,8 @@ pub mod summary {
     use std::collections::HashMap;
     use serde::{self, Serialize, Deserialize};
 
+    use date::Date;
+
     /// One decimal place rounded percent
     #[derive(Debug, Copy, Clone)]
     pub struct Percent(pub f64);
@@ -81,7 +83,7 @@ pub mod summary {
 
         /// 12 week long list of dates from which data was used for that week.
         /// First week in vector is the current week.
-        pub dates: Vec<String>,
+        pub dates: Vec<Date>,
     }
 }
 
@@ -100,10 +102,8 @@ pub mod info {
 }
 
 pub mod data {
-    use serde_json::Value;
-
     use load::Kind;
-    use server::{GroupBy, OptionalDate};
+    use server::{DateData, GroupBy, OptionalDate};
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Request {
@@ -131,12 +131,13 @@ pub mod data {
     ///       - time: f64 of duration for compiling (TODO: Is this in seconds?)
     // TODO: Use a struct instead of Value.
     #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct Response(pub Vec<Value>);
+    pub struct Response(pub Vec<DateData>);
 }
 
 pub mod tabular {
     use std::collections::HashMap;
 
+    use date::Date;
     use load::{Kind, Timing};
     use server::OptionalDate;
 
@@ -152,15 +153,13 @@ pub mod tabular {
 
         /// Mapping of all crates timed on this date to their timings by phase
         pub data: HashMap<String, HashMap<String, Timing>>,
-        pub date: String,
+        pub date: Date,
     }
 }
 
 pub mod days {
-    use serde_json::Value;
-
     use load::Kind;
-    use server::{OptionalDate, GroupBy};
+    use server::{DateData, OptionalDate, GroupBy};
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Request {
@@ -176,14 +175,15 @@ pub mod days {
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct Response(pub Vec<Value>);
+    pub struct Response(pub Vec<DateData>);
 }
 
 pub mod stats {
-    use serde_json::Value;
+    use std::collections::HashMap;
 
+    use date::Date;
     use load::Kind;
-    use server::OptionalDate;
+    use server::{OptionalDate, Stats};
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Request {
@@ -204,9 +204,9 @@ pub mod stats {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Response {
         #[serde(rename="startDate")]
-        pub start_date: String,
+        pub start_date: Date,
         #[serde(rename="endDate")]
-        pub end_date: String,
-        pub crates: Value,
+        pub end_date: Date,
+        pub crates: HashMap<String, Stats>,
     }
 }

--- a/rs-backend/src/date.rs
+++ b/rs-backend/src/date.rs
@@ -1,0 +1,39 @@
+use chrono::{UTC, DateTime};
+use serde::{self, Serialize, Deserialize};
+
+#[derive(Debug, Copy, Clone)]
+pub struct Date(pub DateTime<UTC>);
+
+// TODO: Deprecate and replace with RFC3339 dates.
+const JS_DATE_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S.000Z";
+
+impl Serialize for Date {
+    fn serialize<S>(&self, serializer: &mut S) -> ::std::result::Result<(), S::Error>
+        where S: serde::ser::Serializer
+    {
+        serializer.serialize_str(&self.0.format(JS_DATE_FORMAT).to_string())
+    }
+}
+
+impl Deserialize for Date {
+    fn deserialize<D>(deserializer: &mut D) -> ::std::result::Result<Date, D::Error>
+        where D: serde::de::Deserializer
+    {
+        struct DateVisitor;
+
+        impl serde::de::Visitor for DateVisitor {
+            type Value = Date;
+
+            fn visit_str<E>(&mut self, value: &str) -> ::std::result::Result<Date, E>
+                where E: serde::de::Error
+            {
+                match DateTime::parse_from_str(value, JS_DATE_FORMAT) {
+                    Ok(value) => Ok(Date(value.with_timezone(&UTC))),
+                    Err(_) => Err(serde::de::Error::invalid_value(value)),
+                }
+            }
+        }
+
+        deserializer.deserialize(DateVisitor)
+    }
+}

--- a/rs-backend/src/lib.rs
+++ b/rs-backend/src/lib.rs
@@ -36,6 +36,7 @@ mod errors {
 }
 
 mod git;
+mod date;
 mod route_handler;
 
 pub mod api;

--- a/rs-backend/src/lib.rs
+++ b/rs-backend/src/lib.rs
@@ -36,8 +36,10 @@ mod errors {
 }
 
 mod git;
-pub mod load;
 mod route_handler;
+
+pub mod api;
+pub mod load;
 pub mod server;
 pub mod util;
 

--- a/rs-backend/src/load.rs
+++ b/rs-backend/src/load.rs
@@ -123,7 +123,10 @@ impl InputData {
                 let timings = make_times(times, test_name == "rustc");
                 for (crate_name, crate_timings) in timings {
                     if run.by_crate.contains_key(&crate_name) {
-                        println!("Overwriting {} from {}, dated {}", crate_name, filename, date);
+                        println!("Overwriting {} from {}, dated {}",
+                                 crate_name,
+                                 filename,
+                                 date);
                     }
 
                     run.by_crate.insert(crate_name, crate_timings);
@@ -212,7 +215,7 @@ impl InputData {
             Err(_) => {
                 match UTC.datetime_from_str(date_str, "%Y-%m-%d-%H-%M-%S") {
                     Ok(dt) => Ok(dt),
-                    Err(err) => Err(err.into())
+                    Err(err) => Err(err.into()),
                 }
             }
         }
@@ -272,7 +275,7 @@ impl TestRun {
 
 /// Contains a single timing, associated with a phase (though the phase name
 /// is not included in the timing).
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
 pub struct Timing {
     pub percent: f64,
     pub time: f64,

--- a/rs-backend/tests/lib.rs
+++ b/rs-backend/tests/lib.rs
@@ -21,6 +21,7 @@ use serde::Serialize;
 
 use rustc_perf::server::{self, GroupBy, OptionalDate};
 use rustc_perf::load::{Kind, InputData};
+use rustc_perf::api::{data, tabular, days, stats};
 
 fn request<H: Handler>(path: &str, handler: &H) -> IronResult<Response> {
     iron_test::request::get(&format!("http://perf.rust-lang.org/{}", path),
@@ -116,7 +117,7 @@ fn info() {
 fn data_crate_benchmarks() {
     let response = post_request("/data",
                                 &*CHAIN,
-                                server::Data {
+                                data::Request {
                                     start_date: OptionalDate::CouldNotParse("".into()),
                                     end_date: OptionalDate::CouldNotParse("".into()),
                                     group_by: GroupBy::Crate,
@@ -132,7 +133,7 @@ fn data_crate_benchmarks() {
 fn data_crate_rustc_total() {
     let response = post_request("/data",
                                 &*CHAIN,
-                                server::Data {
+                                data::Request {
                                     start_date: OptionalDate::CouldNotParse("".into()),
                                     end_date: OptionalDate::CouldNotParse("".into()),
                                     group_by: GroupBy::Crate,
@@ -148,7 +149,7 @@ fn data_crate_rustc_total() {
 fn tabular_rustc() {
     let response = post_request("/get_tabular",
                                 &*CHAIN,
-                                server::Tabular {
+                                tabular::Request {
                                     kind: Kind::Rustc,
                                     date: OptionalDate::CouldNotParse("".into()),
                                 })
@@ -160,7 +161,7 @@ fn tabular_rustc() {
 fn tabular_benchmarks() {
     let response = post_request("/get_tabular",
                                 &*CHAIN,
-                                server::Tabular {
+                                tabular::Request {
                                     kind: Kind::Benchmarks,
                                     date: OptionalDate::CouldNotParse("".into()),
                                 })
@@ -177,7 +178,7 @@ fn ymd_date(year: u64, month: u64, day: u64) -> OptionalDate {
 fn days_benchmarks() {
     let response = post_request("/get",
                                 &*CHAIN,
-                                server::Days {
+                                days::Request {
                                     kind: Kind::Benchmarks,
                                     dates: vec![ymd_date(2016, 02, 21), ymd_date(2016, 03, 22)],
                                     crates: vec!["helloworld".into(), "regex.0.1.30".into()],
@@ -192,7 +193,7 @@ fn days_benchmarks() {
 fn days_rustc() {
     let response = post_request("/get",
                                 &*CHAIN,
-                                server::Days {
+                                days::Request {
                                     kind: Kind::Rustc,
                                     dates: vec![ymd_date(2016, 02, 21), ymd_date(2016, 03, 22)],
                                     crates: vec!["total".into()],
@@ -207,7 +208,7 @@ fn days_rustc() {
 fn stats_benchmarks() {
     let response = post_request("/stats",
                                 &*CHAIN,
-                                server::Stats {
+                                stats::Request {
                                     kind: Kind::Benchmarks,
                                     start_date: OptionalDate::CouldNotParse("".into()),
                                     end_date: OptionalDate::CouldNotParse("".into()),
@@ -222,7 +223,7 @@ fn stats_benchmarks() {
 fn stats_rustc() {
     let response = post_request("/stats",
                                 &*CHAIN,
-                                server::Stats {
+                                stats::Request {
                                     kind: Kind::Rustc,
                                     start_date: OptionalDate::CouldNotParse("".into()),
                                     end_date: OptionalDate::CouldNotParse("".into()),


### PR DESCRIPTION
Excludes on_push handler due to unknown true request.

Modules for each API endpoint are created; declaring the
Request/Response relationship. Both requests and responses are
serializable and deserializable to allow tests to serialize requests.
Responses are currently never deserialized, but the derive is included
for consistency.

Also, let me know where/what you think needs more documentation.... I think I documented everything I thought was worthy of it, so if you think something needs more let me know.

r? @nrc
