### PR TITLE
Add commit SHA into tooltips in graph display.

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -72,7 +72,7 @@ Chart.types.Line.extend({
             var steppedLabels = [];
             for (var i = 0; i < data.labels.length; ++i) {
                 if (i % step == 0) {
-                    steppedLabels.push(data.labels[i]);
+                    steppedLabels.push(data.axisLabels[i]);
                 } else {
                     steppedLabels.push("");
                 }
@@ -178,6 +178,7 @@ function init_graph(data, series, field, total_label) {
     var ctx = document.getElementById("graph").getContext("2d");
 
     var labels = [];
+    var axisLabels = [];
     var values = [];
 
     for (var i in series) { values.push([]) }
@@ -185,7 +186,8 @@ function init_graph(data, series, field, total_label) {
         var datum = data[d];
 
         var date = new Date(datum.date);
-        labels.push(date.toLocaleString());
+        labels.push(date.toLocaleString() + " - " + datum.commit.substr(0, 10));
+        axisLabels.push(date.toLocaleString());
 
         for (var i in series) {
             if (series[i] in datum.data) {
@@ -224,7 +226,8 @@ function init_graph(data, series, field, total_label) {
 
     var chart_data = {
         labels: labels,
-        datasets: datasets
+        datasets: datasets,
+        axisLabels: axisLabels,
     };
 
     ctx.clearRect(0, 0, 1000, 600);


### PR DESCRIPTION
Included an image of how it looks. Unfortunately, I don't believe there is any good way to allow selecting text from the tooltip.

![image](https://cloud.githubusercontent.com/assets/5047365/17815861/5da67bee-65f3-11e6-8c89-fc87412023b4.png)

Helps with #61, but an incomplete fix (no diff or link, not possible to click).