### PR TITLE
Frontend code cleanup

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -105,7 +105,8 @@
                 populate_data(data);
                 document.getElementById("loading").style.display = "none";
                 set_check_boxes(kind, crates, phases, group_by);
-                set_dates(data[0].date, data[1].date);
+                document.getElementById("date-a").value = new Date(data[0].date).toISOString().split('T')[0];
+                document.getElementById("date-b").value = new Date(data[1].date).toISOString().split('T')[0];
 
                 if (push_state) {
                     push_state_to_history(keys, [[data[0].date, data[1].date], kind, crates, phases, group_by]);

--- a/index.html
+++ b/index.html
@@ -10,9 +10,7 @@
     <div id="summary_number"></div>
     <div id="summary_table"></div>
 </body>
-    <script src="libs/Chart.min.js"></script>
     <script src="libs/fetch.js"></script>
-    <script src="graph.js"></script>
     <script src="shared.js"></script>
     <script>
     fetch("http://perf.rust-lang.org/perf/summary").then(function(response) {


### PR DESCRIPTION
# Unused scripts:
Missed these in the UI update, didn't expect a page without a graph to load the graphing scripts.

It's possible they were there for caching purposes, if so I can re-add and change the graphing library to load the correct one. I don't see much point though, the site most definitely will not work without internet (since we dynamically load the data).

# JS looking up element with wrong ID:
Slight code duplication, but I felt that was better at least for now, as opposed to passing in the IDs