### PR TITLE
Allow zooming on both axes

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -59,7 +59,7 @@ function init_graph(data, series, field, total_label, yAxisLabel) {
     }
     chart = new Highcharts.Chart({
         chart: {
-            zoomType: "x",
+            zoomType: "xy",
             renderTo: "chart-container",
             type: "line",
         },


### PR DESCRIPTION
@eddyb wanted this.

I'm still not 100% sure that this solution is the absolutely correct one, perhaps instead we should look into some way to "delete" points, or exclude them temporarily.

I believe the problem that we are trying to solve here is that some points are outliers, and we want to view things around them, but there's no way to exclude a point in the middle of a dataset currently. This is a workaround, since it allows selecting a box on the graph. I believe this hurts us in some ways by not allowing the easy x-axis zooming that was present before, since you have to select the entire region you will see right away.

