### PR TITLE
Use one base URL in shared.js for fetching

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -100,7 +100,7 @@
         document.getElementById("loading").style.display = "block";
 
         var values = [dates, kind, crates, phases, group_by];
-        fetch("http://perf.rust-lang.org/perf/get", make_request(keys, values)).then(function(response) {
+        fetch(BASE_URL + "/get", make_request(keys, values)).then(function(response) {
             response.json().then(function(data) {
                 populate_data(data);
                 document.getElementById("loading").style.display = "none";

--- a/graphs.html
+++ b/graphs.html
@@ -45,7 +45,7 @@
     // Make a graph!
     function make_graph(start_date, end_date, kind, crates, phases, group_by, push_state) {
         var values = [start_date, end_date, kind, crates, phases, group_by];
-        fetch("http://perf.rust-lang.org/perf/data", make_request(keys, values)).then(function(response) {
+        fetch(BASE_URL + "/data", make_request(keys, values)).then(function(response) {
             response.json().then(function(data) {
                 var series = crates;
                 if (group_by == "phase") {

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <script src="libs/fetch.js"></script>
     <script src="shared.js"></script>
     <script>
-    fetch("http://perf.rust-lang.org/perf/summary").then(function(response) {
+    fetch(BASE_URL + "/summary").then(function(response) {
         response.json().then(function(data) {
             document.getElementById("loading").style.display = "none";
 

--- a/mem.html
+++ b/mem.html
@@ -45,7 +45,7 @@
     // Make a graph!
     function make_graph(start_date, end_date, kind, crates, phases, group_by, push_state) {
         var values = [start_date, end_date, kind, crates, phases, group_by];
-        fetch("http://perf.rust-lang.org/perf/data", make_request(keys, values)).then(function(response) {
+        fetch(BASE_URL + "/data", make_request(keys, values)).then(function(response) {
             response.json().then(function(data) {
                 var series = crates;
                 if (group_by == "phase") {

--- a/shared.js
+++ b/shared.js
@@ -1,3 +1,5 @@
+var BASE_URL = "http://perf.rust-lang.org/perf";
+
 // Radio button event listener.
 var radios = document.getElementsByName("kind");
 var prev_kind = null;
@@ -87,7 +89,7 @@ function make_settings(callback, total_label) {
     if (!total_label) {
         total_label = "total";
     }
-    return fetch("http://perf.rust-lang.org/perf/info", {}).then(function(response) {
+    return fetch(BASE_URL + "/info", {}).then(function(response) {
         response.json().then(function(data) {
             var crates_html = "";
             crates_html += "<input checked=\"true\" type=\"checkbox\" name=\"check-crate\" id=\"check-crate-total\">" + total_label + "</input></br>";

--- a/stats.html
+++ b/stats.html
@@ -65,7 +65,7 @@
         document.getElementById("loading").style.display = "block";
 
         var values = [start_date, end_date, kind, crates, phases];
-        fetch("http://perf.rust-lang.org/perf/stats", make_request(keys, values)).then(function(response) {
+        fetch(BASE_URL + "/stats", make_request(keys, values)).then(function(response) {
             response.json().then(function(data) {
                 populate_stats(data);
                 document.getElementById("loading").style.display = "none";

--- a/table.html
+++ b/table.html
@@ -33,7 +33,7 @@
     }
 
     function make_table(kind, date, push_state) {
-        fetch("http://perf.rust-lang.org/perf/get_tabular", make_request(keys, [kind, date])).then(function(response) {
+        fetch(BASE_URL + "/get_tabular", make_request(keys, [kind, date])).then(function(response) {
             response.json().then(function(data) {
                 set_date(date);
                 populate_table(data);


### PR DESCRIPTION
Minimizes difference when using different backend servers.

Ideally, we'd abstract the usage of BASE_URL away (custom fetch function, perhaps) but that requires more work than this relatively simple PR.

Fixes #77.