### PR TITLE
Show - instead of 0% on summary page when no data is given

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
     function cell_for_data(datum) {
         if (!datum) {
-            datum = 0;
+            return "<td>-</td>";
         }
         var d_class = "";
         if (parseFloat(datum) <= -1) {


### PR DESCRIPTION
This is a "temporary" fix for indicating when crates don't build (#68),
which works given the following:

 * All crates in rustc-benchmarks currently build
   * Coinciding with this commit, PRs have been filed against
     rust-lang-nursery/rustc-benchmarks to fix or remove currently broken
     crates there.
 * New additions to benchmarks will build at least once successfully
 * Someone will notice within 13 weeks of the addition if something is
   broken