### PR TITLE
Show - instead of 0% on summary page when no data is given

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 
     function cell_for_data(datum) {
         if (!datum) {
-            datum = 0;
+            return "<td>-</td>";
         }
         var d_class = "";
         if (parseFloat(datum) <= -1) {


### PR DESCRIPTION
This is a "temporary" fix for indicating when crates don't build (#68),
which works given the following:

 * All crates in rustc-benchmarks currently build
   * Coinciding with this commit, PRs have been filed against
     rust-lang-nursery/rustc-benchmarks to fix or remove currently broken
     crates there.
 * New additions to benchmarks will build at least once successfully
 * Someone will notice within 13 weeks of the addition if something is
   broken

The whole fix would involve updating the processing scripts to encode
when errors occur, which is considered difficult by the author of this
PR: the updates required to process.py in
rust-lang-nursery/rustc-timing-scripts are unknown, though the summary
is that errors/unparseability needs to be detected and handled.

It is proposed that in the future, process.py would be modified to
include which raw log file contained the error so that the frontend
could then display a direct link to it (likely somewhere on GitHub) for
examination.