### PR TITLE
Make cells on summary page link to time graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,23 +15,27 @@
     <script src="shared.js"></script>
     <script>
     make_as_of();
+    var info_data;
     fetch(BASE_URL + "/summary").then(function(response) {
         response.json().then(function(data) {
-            document.getElementById("loading").style.display = "none";
+            fetch(BASE_URL + "/info").then(response => response.json()).then(info => {
+                info_data = info;
 
-            var summary_number = document.getElementById("summary_number");
-            var big_value = data.summaries[0];
-            var big_class = "";
-            if (parseFloat(big_value) <= -1) {
-                big_class = " negative";
-            } else if (parseFloat(big_value) >= 1) {
-                big_class = " positive";
-            }
-            summary_number.innerHTML = "<div>In the past week, compile times have increased by:</div><div class=\"big_summary" + big_class + "\">" + big_value + "%</div><div>(Lower is better).</div>";
-            summary_number.style.display = "block";
+                var summary_number = document.getElementById("summary_number");
+                var big_value = data.summaries[0];
+                var big_class = "";
+                if (parseFloat(big_value) <= -1) {
+                    big_class = " negative";
+                } else if (parseFloat(big_value) >= 1) {
+                    big_class = " positive";
+                }
+                summary_number.innerHTML = "<div>In the past week, compile times have increased by:</div><div class=\"big_summary" + big_class + "\">" + big_value + "%</div><div>(Lower is better).</div>";
+                summary_number.style.display = "block";
 
-            populate_table(data);
+                populate_table(data);
 
+                document.getElementById("loading").style.display = "none";
+            });
         });
     }, function(err) {
         document.getElementById("loading").innerHTML = "Error loading data";
@@ -55,7 +59,7 @@
         for (var b of bench_keys) {
             html += "<tr><th>" + b + "</th>"
             for (var i = week_count - 1; i >= 0; --i) {
-                html += cell_for_data(data.breakdown[i][b]);
+                html += cell_for_data(data.breakdown[i][b], b, data.dates, i);
             }
             html += cell_for_data(data.total_breakdown[b]);
             html += "</tr>";
@@ -72,18 +76,42 @@
         document.getElementById("summary_table").style.display = "block";
     }
 
-    function cell_for_data(datum) {
+    function cell_for_data(datum, crate, dates, index) {
         if (!datum) {
             return "<td>-</td>";
         }
-        var d_class = "";
+        var d_class = "neutral";
         if (parseFloat(datum) <= -1) {
             d_class = " negative";
         } else if (parseFloat(datum) >= 1) {
             d_class = " positive";
         }
 
-        return "<td class=\"" + d_class + "\">" + datum + "%</td>";
+        if (dates) {
+            let start = new Date(dates[index]);
+            start.setDate(start.getDate() - 7);
+            let end = new Date(dates[index]);
+
+            let kind;
+            if (crate == "bootstrap") {
+                kind = "rustc";
+                crate = "total";
+            } else {
+                kind = "benchmarks";
+            }
+
+            let href = "<a class=\"" + d_class + "\" href=\"" + "/graphs.html" + query_string_for_state({
+                start: start,
+                end: end,
+                kind: kind,
+                group_by: "phase",
+                crates: [crate],
+                phases: info_data.phases,
+            }) + "\">" + datum + "%</a>";
+            return "<td>" + href + "</td>";
+        } else {
+            return "<td class=\"" + d_class + "\">" + datum + "%</td>";
+        }
     }
     </script>
 </html>

--- a/perf.css
+++ b/perf.css
@@ -130,6 +130,9 @@ img {
 .negative {
   color: green;
 }
+.neutral {
+  color: black;
+}
 .summary_table td {
   padding: 4px;
   text-align: center;


### PR DESCRIPTION
Only the time graph is currently supported, since most of the time, it
is the one the user cares about.

The total column is not supported since it is rare that someone will
care about improvement over the past 13 weeks, but it should be
relatively simple to add it if requested; though the changes will not be
trivial.

The implementation currently queries the info endpoint for the phase
list to pass to the graphs page, but the ideal way to do this would be a
meta "all_phases" phase name we could pass instead.

r? @nrc

cc @nikomatsakis

Potentially fixes this issue: #60, potentially some other issues as well.