### PR TITLE
Replace strings including \" with template string literals

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -71,7 +71,7 @@
             html += "<td>-</td>";
         }
 
-        html += "<td class=\"space\"></td>";
+        html += `<td class="space"></td>`;
 
         return html;
     }
@@ -80,9 +80,9 @@
         if (a && b && a[field] > 0) {
             let percent = 100 * (b[field] - a[field]) / a[field];
             if (percent > 0) {
-                return "<td class=\"positive\">" + percent.toFixed(1) + "%" + "</td>";
+                return `<td class="positive">${percent.toFixed(1)}%</td>`;
             } else {
-                return "<td class=\"negative\">" + percent.toFixed(1) + "%" + "</td>";
+                return `<td class="negative">${percent.toFixed(1)}%</td>`;
             }
         } else {
             return "<td>-</td>"
@@ -90,18 +90,18 @@
     }
 
     function populate_data(data) {
-        let html = "<table class=\"compare\" style=\"font-size: medium !important;\">";
+        let html = `<table class="compare" style="font-size: medium !important;">`;
 
         // Heading: the two dates, and the time and rss percent changes.
         html += "<thead>";
         html += "<tr>";
-        html += "<td class=\"space\"></td>";
-        html += "<td class=\"space\"></td>";
+        html += `<td class="space"></td>`;
+        html += `<td class="space"></td>`;
 
         html += "<th colspan=2>" + new Date(data.a.date).toLocaleString() + "</th>";
-        html += "<td class=\"space\"></td>";
+        html += `<td class="space"></td>`;
         html += "<th colspan=2>" + new Date(data.b.date).toLocaleString() + "</th>";
-        html += "<td class=\"space\"></td>";
+        html += `<td class="space"></td>`;
 
         html += "<th>" + "% change (time)" + "</th>";
         html += "<th>" + "% change (rss)" + "</th>";
@@ -114,7 +114,7 @@
             html += "<tr>";
 
             html += "<th>" + truncate_name(name) + "</th>";
-            html += "<td class=\"space\"></td>";
+            html += `<td class="space"></td>`;
 
             html += add_datum_fields(data.a.data[name]);
             html += add_datum_fields(data.b.data[name]);

--- a/index.html
+++ b/index.html
@@ -25,11 +25,14 @@
                 var big_value = data.summaries[0];
                 var big_class = "";
                 if (parseFloat(big_value) <= -1) {
-                    big_class = " negative";
+                    big_class = "negative";
                 } else if (parseFloat(big_value) >= 1) {
-                    big_class = " positive";
+                    big_class = "positive";
                 }
-                summary_number.innerHTML = "<div>In the past week, compile times have increased by:</div><div class=\"big_summary" + big_class + "\">" + big_value + "%</div><div>(Lower is better).</div>";
+                let html = "<div>In the past week, compile times have increased by:</div>";
+                html += `<div class="big_summary ${big_class}">${big_value}%</div>`;
+                html += "<div>(Lower is better).</div>";
+                summary_number.innerHTML = html;
                 summary_number.style.display = "block";
 
                 populate_table(data);
@@ -50,7 +53,7 @@
         var bench_keys = Object.keys(data.breakdown[0]);
         bench_keys.sort();
 
-        var html = "<table class=\"summary_table\"><tr><th></th>";
+        var html = `<table class="summary_table"><tr><th></th>`;
         for (var i = week_count - 1; i >= 0; --i) {
             var date = new Date(data.dates[i]);
             html += "<th>" + date.toLocaleDateString() + "</th>"
@@ -82,9 +85,9 @@
         }
         var d_class = "neutral";
         if (parseFloat(datum) <= -1) {
-            d_class = " negative";
+            d_class = "negative";
         } else if (parseFloat(datum) >= 1) {
-            d_class = " positive";
+            d_class = "positive";
         }
 
         if (dates) {
@@ -100,17 +103,17 @@
                 kind = "benchmarks";
             }
 
-            let href = "<a class=\"" + d_class + "\" href=\"" + "/graphs.html" + query_string_for_state({
+            let query_str = query_string_for_state({
                 start: start,
                 end: end,
                 kind: kind,
                 group_by: "phase",
                 crates: [crate],
                 phases: info_data.phases,
-            }) + "\">" + datum + "%</a>";
-            return "<td>" + href + "</td>";
+            });
+            return `<td><a class="${d_class}" href="/graphs.html${query_str}">${datum}%</a></td>`;
         } else {
-            return "<td class=\"" + d_class + "\">" + datum + "%</td>";
+            return `<td class="${d_class}">${datum}%</td>`;
         }
     }
     </script>

--- a/shared.js
+++ b/shared.js
@@ -88,9 +88,9 @@ function addTotalHandler(name) {
 function make_settings(callback, total_label) {
     function checkbox(name, id, checked, body) {
         if (checked) {
-            return "<input type=\"checkbox\" checked=\"true\" name=\"" + name + "\" id=\"" + id + "\">" + body + "</input></br>";
+            return `<input type="checkbox" checked="true" name="${name}" id="${id}">${body}</input></br>`;
         } else {
-            return "<input type=\"checkbox\" name=\"" + name + "\" id=\"" + id + "\">" + body + "</input></br>";
+            return `<input type="checkbox" name="${name}" id="${id}">${body}</input></br>`;
         }
     }
 

--- a/stats.html
+++ b/stats.html
@@ -56,11 +56,11 @@
         var endDate = new Date(data.endDate);
         var html = "<h2>" + startDate.toLocaleString() + " to " + endDate.toLocaleString() + "</h2>";
 
-        html += "<table class=\"stats\" style=\"font-size: medium !important;\">";
+        html += `<table class="stats" style="font-size: medium !important;">`;
         html += "<thead>";
         html += "<tr>";
         html += "<td></td>"; // test name placeholder
-        html += "<td class=\"space\"></td>";
+        html += `<td class="space"></td>`;
         html += "<th>Mean</th>";
         html += "<th>Min</th>";
         html += "<th>Max</th>";
@@ -75,7 +75,7 @@
             var crate = data.crates[c];
             html += "<tr>";
             html += "<th>" + truncate_name(c) + "</th>";
-            html += "<td class=\"space\"></td>";
+            html += `<td class="space"></td>`;
             html += "<td>" + crate.mean.toFixed(2) + "s" + "</td>";
             html += "<td>" + crate.min.toFixed(2) + "s" + "</td>";
             html += "<td>" + crate.max.toFixed(2) + "s" + "</td>";


### PR DESCRIPTION
This cuts down on line length and allows for string interpolation.

All modern browsers support template string literals, excluding IE 11
and and Safari 7.1 and 8. This is considered sufficient by the author.