### PR TITLE
Align all table cells to the right

### DIFF
--- a/perf.css
+++ b/perf.css
@@ -135,11 +135,9 @@ img {
 }
 .summary_table td {
   padding: 4px;
-  text-align: center;
 }
 .summary_table th {
   padding: 4px;
-  text-align: left;
 }
 
 #as-of {
@@ -154,7 +152,7 @@ img {
   padding: 0.3em;
 }
 
-.stats tr th:first-child, .compare tr th:first-child {
+table td, table th {
   text-align: right;
 }
 


### PR DESCRIPTION
Most table cells are either numbers or number column headers.

The first column is usually a list of phase/crate names, but aligning it
right is decent, though not great, visually; aligning it otherwise is
not significantly better either.

Fixes #102.