### PR TITLE
Display only the current series in graph tooltips

### DIFF
--- a/graph.js
+++ b/graph.js
@@ -71,16 +71,12 @@ function init_graph(data, series, field, total_label, yAxisLabel) {
         },
         series: datasets,
         tooltip: {
-            shared: true,
             crosshairs: [true],
             formatter: function () {
                 var date = new Date(this.x);
-                var commit = this.points[0].point.commit.substr(0, 10);
-                var s = "<b>" + date.toLocaleString() + " - " + commit + "</b>";
-                for (let point of this.points) {
-                    s += "<br/>" + point.series.name + ": " + point.y;
-                }
-                return s;
+                var commit = this.point.commit.substr(0, 10);
+                return "<b>" + date.toLocaleString() + " - " + commit + "</b>" +
+                    "<br>" + this.series.name + ": " + this.y;
             }
         },
         xAxis: {


### PR DESCRIPTION
It is hard to tell which data point is the current one when many series
are displayed, so we should only display one series in the graph
tooltip. Relative comparisons more so than exact comparisons are
generally made on the graph page, and exact data often varies from
run-to-run even without changes to the compiler, so this change should
not hurt usability overall, and in fact should improve it.

Potential future work could involve finding a way to query the previous
and next series in a given "column" on the graph, and display the series
data for those two data points.

Before:
![image](https://cloud.githubusercontent.com/assets/5047365/18820343/0307e4f0-835a-11e6-876c-9e1d008fb25e.png)

After:
![image](https://cloud.githubusercontent.com/assets/5047365/18820329/e603e02a-8359-11e6-83d3-c2c6fbce094d.png)

Fixes #104