### PR TITLE
Don't make the link to graphs absolute

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
                 crates: [crate],
                 phases: info_data.phases,
             });
-            return `<td><a class="${d_class}" href="/graphs.html${query_str}">${datum}%</a></td>`;
+            return `<td><a class="${d_class}" href="graphs.html${query_str}">${datum}%</a></td>`;
         } else {
             return `<td class="${d_class}">${datum}%</td>`;
         }


### PR DESCRIPTION
This aid debugging, and since all of our pages are in the root anyway,
it doesn't affect perf.rlo.