### PR TITLE
Make backend queries independent of hosting location.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,3 @@ pub mod load;
 pub mod date;
 pub mod util;
 pub mod server;
-
-const SERVER_ADDRESS: &'static str = "0.0.0.0:2346";

--- a/src/load.rs
+++ b/src/load.rs
@@ -199,7 +199,7 @@ pub struct Comparison {
     pub b: Commit,
 
     /// Maps crate names to a map of phases to each phase's delta time over the range.
-    pub by_crate: HashMap<String, HashMap<String, f64>>,
+    pub by_crate: BTreeMap<String, BTreeMap<String, f64>>,
 }
 
 #[derive(Debug)]
@@ -253,7 +253,7 @@ impl Summary {
     }
 
     fn compare_points(a: &CommitData, b: &CommitData) -> Comparison {
-        let mut by_crate = HashMap::new();
+        let mut by_crate = BTreeMap::new();
         for (crate_name, patches) in &a.benchmarks {
             if !b.benchmarks.contains_key(crate_name) {
                 warn!("Comparing {} with {}: a contained {}, but b did not.",
@@ -274,7 +274,7 @@ impl Summary {
                     let a_t = a_pass.time;
                     let b_t = b_run.get_pass(&a_pass.name).map(|p| p.time).unwrap_or(0.0);
                     by_crate.entry(a_run.name.clone())
-                        .or_insert_with(HashMap::new)
+                        .or_insert_with(BTreeMap::new)
                         .insert(a_pass.name.clone(), b_t - a_t);
                 }
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,12 +8,14 @@
 // except according to those terms.
 
 use std::str;
+use std::env;
 use std::cmp::max;
 use std::fs::File;
 use std::io::Read;
 use std::sync::{RwLock, Arc};
 use std::collections::{HashMap, BTreeMap};
 use std::path::Path;
+use std::net::SocketAddr;
 
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -484,6 +486,8 @@ pub fn start(data: InputData) {
         data: Arc::new(RwLock::new(data)),
         pool: CpuPool::new_num_cpus(),
     });
-    let server = Http::new().bind(&::SERVER_ADDRESS.parse().unwrap(), move || Ok(server.clone()));
+    let mut server_address: SocketAddr = "0.0.0.0:2346".parse().unwrap();
+    server_address.set_port(env::var("PORT").ok().and_then(|x| x.parse().ok()).unwrap_or(2346));
+    let server = Http::new().bind(&server_address, move || Ok(server.clone()));
     server.unwrap().run().unwrap();
 }

--- a/static/shared.js
+++ b/static/shared.js
@@ -1,4 +1,4 @@
-var BASE_URL = "http://perf.rust-lang.org/perf";
+var BASE_URL = window.location.origin + "/perf";
 
 function getDate(id) {
     var result = document.getElementById(id).value;


### PR DESCRIPTION
This makes the frontend much more resilient to changing from localhost,
to perf.rlo, etc.

We also support PORT as an environment variable to override the default
2346.