### PR TITLE
Change handling of state to pass objects around.

### DIFF
--- a/static/compare.html
+++ b/static/compare.html
@@ -6,7 +6,6 @@
 </head>
 <body class="container">
     <div>&gt;  <a href="graphs.html">graphs</a>, <a href="stats.html">stats</a>, comparisons, <a href="mem.html">memory graph</a>, <a href="table.html">table view</a>.</div>
-    <div id="loading" style="display: none">loading...</div>
     <div id="content" style="display: none"></div>
     <div id="settings">
         <span id="crates-outer" class="settings">
@@ -28,7 +27,7 @@
             start date: <input placeholder="yyyy-mm-dd" id="date-a"></input><br>
             end date: <input placeholder="yyyy-mm-dd" id="date-b"></input>
             <div class="submit">
-                <a href="#" onClick="remake_data(); return false;">Submit</a>
+                <a href="#" onClick="make_data({}, true); return false;">Submit</a>
             </div>
         </div>
     </div>
@@ -100,6 +99,7 @@
         html += "</thead>";
 
         let test_names = unique([...Object.keys(data.a.data), ...Object.keys(data.b.data)]);
+        test_names.sort();
 
         for (let name of test_names) {
             html += "<tr>";
@@ -122,9 +122,12 @@
         document.getElementById("content").style.display = "block";
     }
 
-    function make_data(datea, dateb, crates, phases, group_by, push_state) {
-        document.getElementById("loading").innerHTML = "loading...";
-        document.getElementById("loading").style.display = "block";
+    function make_data(state, push_state) {
+        let datea = state.date_a || getDate("date-a");
+        let dateb = state.date_b || getDate("date-b");
+        let crates = state.crates || gatherChecks("check-crate");
+        let phases = state.phases || gatherChecks("check-phase");
+        let group_by = state.group_by || "crate";
 
         var values = {
             date_a: datea,
@@ -141,64 +144,22 @@
                 set_date("date-b", data.b.date);
 
                 if (push_state) {
-                    push_state_to_history(values);
+                    push_state_to_history({
+                        date_a: data.a.date,
+                        date_b: data.b.date,
+                        crates: crates,
+                        phases: phases,
+                        group_by: group_by
+                    });
                 }
 
-                document.getElementById("loading").style.display = "none";
             });
         }, function(err) {
-            document.getElementById("loading").innerHTML = "Error loading data";
             console.log("Error fetching data:");
             console.log(err);
         });
     }
 
-    // Read the various settings, then call make_graph.
-    function remake_data() {
-        document.getElementById("content").style.display = "none";
-
-        // crates and phases
-        var crates = gatherChecks("check-crate");
-        var phases = gatherChecks("check-phase");
-
-        // dates
-        var datea = getDate("date-a");
-        var dateb = getDate("date-b");
-
-        // group by
-        var group_by;
-        var elements = document.getElementsByName("groupBy");
-        for (var i = 0, l = elements.length; i < l; i++)
-        {
-            if (elements[i].checked)
-            {
-                group_by = elements[i].value;
-                break;
-            }
-        }
-        if (!group_by) {
-            group_by = "crate";
-            document.getElementById("group-by-crate").checked = true;
-        }
-
-        make_data(datea, dateb, crates, phases, group_by, true);
-    }
-
-    make_settings(function() {
-        // FIXME: implement serializing to URL
-        // // Respond to back/forwards properly.
-        // window.onpopstate = function(ev) {
-        //     var state = ev.state;
-        //     if (!dispatch_on_state(make_data, state, keys)) {
-        //         if (!dispatch_on_params(make_data, keys)) {
-        //             document.getElementById("loading").style.display = "none";
-        //             document.getElementById("content").style.display = "none";
-        //         }
-        //     }
-        // };
-
-        // // Load the page from a URL.
-        // dispatch_on_params(make_data);
-    });
+    make_settings(make_data);
     </script>
 </html>

--- a/static/graphs.html
+++ b/static/graphs.html
@@ -6,7 +6,6 @@
 </head>
 <body class="container">
     <div>&gt;  graphs, <a href="stats.html">stats</a>, <a href="compare.html">comparisons</a>, <a href="mem.html">memory graph</a>, <a href="table.html">table view</a>.</div>
-    <div id="loading">loading...</div>
     <div style="width: 1000px; height: 600px;" id="chart-container"></div>
     <div id="settings">
         <span id="crates-outer" class="settings">
@@ -28,7 +27,7 @@
             start date: <input placeholder="yyyy-mm-dd" id="start-date"></input><br>
             end date: <input placeholder="yyyy-mm-dd" id="end-date"></input>
             <div class="submit">
-                <a href="#" onClick="remake_graph(); return false;">Submit</a>
+                <a href="#" onClick="make_graph({}, true); return false;">Submit</a>
             </div>
         </div>
     </div>
@@ -39,38 +38,38 @@
     <script src="graph.js"></script>
     <script src="shared.js"></script>
     <script>
-    let keys = ["start", "end", "crates", "phases", "group_by"];
-    make_as_of();
-    // Make a graph!
-    function make_graph(start_date, end_date, crates, phases, group_by, push_state) {
+    function make_graph(state, push_state) {
+        let start_date = state.start || getDate("start-date");
+        let end_date = state.end || getDate("end-date");
+        let crates = state.crates || gatherChecks("check-crate");
+        let phases = state.phases || gatherChecks("check-phase");
+        let group_by = state.group_by || "crate";
+
         var values = {
             start: start_date,
             end: end_date,
             crates: crates,
             phases: phases,
-            group_by: group_by
+            group_by: group_by,
         };
         fetch(BASE_URL + "/data", make_request(values)).then(function(response) {
             response.json().then(function(data) {
+                if (data.length > 0) {
+                    start_date = data[0].date;
+                    end_date = data[data.length - 1].date;
+                }
                 var series = crates;
                 if (group_by == "phase") {
                     series = phases;
                 }
 
                 set_check_boxes(crates, phases, group_by);
-                set_date("start-date", start_date)
+                set_date("start-date", start_date);
                 set_date("end-date", end_date);
 
                 init_graph(data, series, "time", undefined, "Seconds");
-                document.getElementById("loading").style.display = "none";
 
                 if (push_state) {
-                    var start_date = "";
-                    var end_date = "";
-                    if (data.length > 0) {
-                        start_date = data[0].date;
-                        end_date = data[data.length - 1].date;
-                    }
                     push_state_to_history({
                         start: start_date,
                         end: end_date,
@@ -81,57 +80,11 @@
                 }
             });
         }, function(err) {
-            document.getElementById("loading").innerHTML = "Error loading data";
             console.log("Error fetching data:");
             console.log(err);
         });
     }
 
-    // Read the various settings, then call make_graph.
-    function remake_graph() {
-        document.getElementById("loading").style.display = "block";
-
-        // crates and phases
-        var crates = gatherChecks("check-crate");
-        var phases = gatherChecks("check-phase");
-
-        // dates
-        var start_date = getDate("start-date");
-        var end_date = getDate("end-date");
-
-        // group by
-        var group_by;
-        var elements = document.getElementsByName("groupBy");
-        for (var i = 0, l = elements.length; i < l; i++) {
-            if (elements[i].checked) {
-                group_by = elements[i].value;
-                break;
-            }
-        }
-        if (!group_by) {
-            group_by = "crate";
-            document.getElementById("group-by-crate").checked = true;
-        }
-
-        make_graph(start_date, end_date, crates, phases, group_by, true);
-    }
-
-    make_settings(function() {
-       // Respond to back/forwards properly.
-       window.onpopstate = function(ev) {
-           var state = ev.state;
-           if (!dispatch_on_state(make_graph, state, keys)) {
-               if (!dispatch_on_params(make_graph, keys)) {
-                   make_graph("", "", ["total"], ["total"], "crate", false);
-               }
-           }
-       };
-
-       // Load the page from a URL.
-       if (!dispatch_on_params(make_graph, keys)) {
-           make_graph("", "", ["total"], ["total"], "crate", false);
-           remake_graph();
-       }
-    });
+    make_settings(make_graph);
     </script>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,6 @@
     <script src="libs/fetch.js"></script>
     <script src="shared.js"></script>
     <script>
-    make_as_of();
     var info_data;
     fetch(BASE_URL + "/summary").then(function(response) {
         response.json().then(function(data) {

--- a/static/mem.html
+++ b/static/mem.html
@@ -6,7 +6,6 @@
 </head>
 <body class="container">
     <div>&gt; <a href="graphs.html">graphs</a>, <a href="stats.html">stats</a>, <a href="compare.html">comparisons</a>, memory graph, <a href="table.html">table view</a>.</div>
-    <div id="loading">loading...</div>
     <div style="width: 1000px; height: 600px;" id="chart-container"></div>
     <div id="settings">
         <span id="crates-outer" class="settings">
@@ -28,7 +27,7 @@
             start date: <input placeholder="yyyy-mm-dd" id="start-date"></input><br>
             end date: <input placeholder="yyyy-mm-dd" id="end-date"></input>
             <div class="submit">
-                <a href="#" onClick="remake_graph(); return false;">Submit</a>
+                <a href="#" onClick="make_graph({}, true); return false;">Submit</a>
             </div>
         </div>
     </div>
@@ -39,10 +38,13 @@
     <script src="graph.js"></script>
     <script src="shared.js"></script>
     <script>
-    let keys = ["start", "end", "crates", "phases", "group_by"];
-    make_as_of();
-    // Make a graph!
-    function make_graph(start_date, end_date, crates, phases, group_by, push_state) {
+    function make_graph(state, push_state) {
+        let start_date = state.start || getDate("start-date");
+        let end_date = state.end || getDate("end-date");
+        let crates = state.crates || gatherChecks("check-crate");
+        let phases = state.phases || gatherChecks("check-phase");
+        let group_by = state.group_by || "crate";
+
         let values = {
             start: start_date,
             end: end_date,
@@ -52,20 +54,25 @@
         };
         fetch(BASE_URL + "/data", make_request(values)).then(function(response) {
             response.json().then(function(data) {
+                if (data.length > 0) {
+                    start_date = data[0].date;
+                    end_date = data[data.length - 1].date;
+                }
                 var series = crates;
                 if (group_by == "phase") {
                     series = phases;
                 }
-                init_graph(data, series, "rss", "maximum", "Megabytes");
-                document.getElementById("loading").style.display = "none";
+
                 set_check_boxes(crates, phases, group_by);
                 set_date("start-date", start_date);
                 set_date("end-date", end_date);
 
+                init_graph(data, series, "rss", "maximum", "Megabytes");
+
                 if (push_state) {
                     push_state_to_history({
-                        start: data[0].date,
-                        end: data[data.length - 1].date,
+                        start: start_date,
+                        end: end_date,
                         crates: crates,
                         phases: phases,
                         group_by: group_by
@@ -73,60 +80,11 @@
                 }
             });
         }, function(err) {
-            document.getElementById("loading").innerHTML = "Error loading data";
             console.log("Error fetching data:");
             console.log(err);
         });
     }
 
-    // Read the various settings, then call make_graph.
-    function remake_graph() {
-        document.getElementById("loading").style.display = "block";
-
-        // crates and phases
-        var crates = gatherChecks("check-crate");
-        var benchmarks = gatherChecks("check-bench");
-        var phases = gatherChecks("check-phase");
-
-        // dates
-        var start_date = getDate("start-date");
-        var end_date = getDate("end-date");
-
-        // group by
-        var group_by;
-        var elements = document.getElementsByName("groupBy");
-        for (var i = 0, l = elements.length; i < l; i++)
-        {
-            if (elements[i].checked)
-            {
-                group_by = elements[i].value;
-                break;
-            }
-        }
-        if (!group_by) {
-            group_by = "crate";
-            document.getElementById("group-by-crate").checked = true;
-        }
-
-        make_graph(start_date, end_date, crates, phases, group_by, true);
-    }
-
-    make_settings(function() {
-        // Respond to back/forwards properly.
-        window.onpopstate = function(ev) {
-            var state = ev.state;
-            if (!dispatch_on_state(make_graph, state, keys)) {
-                if (!dispatch_on_params(make_graph, keys)) {
-                    make_graph("", "", ["total"], ["total"], "crate", false);
-                }
-            }
-        };
-
-        // // Load the page from a URL.
-        if (!dispatch_on_params(make_graph, keys)) {
-            make_graph("", "", ["total"], ["total"], "crate", false);
-            remake_graph();
-        }
-    }, "maximum");
+    make_settings(make_graph, "maximum");
     </script>
 </html>

--- a/static/stats.html
+++ b/static/stats.html
@@ -6,7 +6,6 @@
 </head>
 <body class="container">
     <div>&gt;  <a href="graphs.html">graphs</a>, stats, <a href="compare.html">comparisons</a>, <a href="mem.html">memory graph</a>, <a href="table.html">table view</a>.</div>
-    <div id="loading" style="display: none">loading...</div>
     <div id="content" style="display: none"></div>
     <div id="settings">
         <span id="crates-outer" class="settings">
@@ -28,7 +27,7 @@
             start date: <input placeholder="yyyy-mm-dd" id="start-date"></input><br>
             end date: <input placeholder="yyyy-mm-dd" id="end-date"></input>
             <div class="submit">
-                <a href="#" onClick="remake_stats(); return false;">Submit</a>
+                <a href="#" onClick="make_stats({}, true); return false;">Submit</a>
             </div>
         </div>
     </div>
@@ -38,7 +37,6 @@
     <script src="shared.js"></script>
     <script>
     let keys = ["start", "end", "crates", "phases"];
-    make_as_of();
     function populate_stats(data) {
         var startDate = new Date(data.startDate);
         var endDate = new Date(data.endDate);
@@ -92,11 +90,13 @@
         document.getElementById("content").style.display = "block";
     }
 
-    function make_stats(start_date, end_date, crates, phases, push_state) {
-        document.getElementById("loading").innerHTML = "loading...";
-        document.getElementById("loading").style.display = "block";
+    function make_stats(state, push_state) {
+        let start_date = state.start || getDate("start-date");
+        let end_date = state.end || getDate("end-date");
+        let crates = state.crates || gatherChecks("check-crate");
+        let phases = state.phases || gatherChecks("check-phase");
 
-        var values = {
+        let values = {
             start: start_date,
             end: end_date,
             crates: crates,
@@ -105,13 +105,17 @@
         fetch(BASE_URL + "/stats", make_request(values)).then(function(response) {
             response.json().then(function(data) {
                 populate_stats(data);
-                document.getElementById("loading").style.display = "none";
                 set_check_boxes(crates, phases, null);
-                set_date("start-date", start_date);
-                set_date("end-date", end_date);
+                set_date("start-date", data.startDate);
+                set_date("end-date", data.endDate);
 
                 if (push_state) {
-                    push_state_to_history(values);
+                    push_state_to_history({
+                        start: data.startDate,
+                        end: data.endDate,
+                        crates,
+                        phases,
+                    });
                 }
             });
         }, function(err) {
@@ -121,35 +125,6 @@
         });
     }
 
-    // Read the various settings, then call make_graph.
-    function remake_stats() {
-        document.getElementById("content").style.display = "none";
-
-        // crates and phases
-        var crates = gatherChecks("check-crate");
-        var phases = gatherChecks("check-phase");
-
-        // dates
-        var start_date = getDate("start-date");
-        var end_date = getDate("end-date");
-
-        make_stats(start_date, end_date, crates, phases, true);
-    }
-
-    make_settings(function() {
-        // Respond to back/forwards properly.
-        window.onpopstate = function(ev) {
-            var state = ev.state;
-            if (!dispatch_on_state(make_stats, state, keys)) {
-                if (!dispatch_on_params(make_stats, keys)) {
-                    document.getElementById("loading").style.display = "none";
-                    document.getElementById("content").style.display = "none";
-                }
-            }
-        };
-
-        // Load the page from a URL.
-        dispatch_on_params(make_stats, keys);
-    });
+    make_settings(make_stats);
     </script>
 </html>

--- a/static/table.html
+++ b/static/table.html
@@ -11,7 +11,7 @@
             <h3>Dates</h3>
             date: <input placeholder="yyyy-mm-dd" id="date"></input><br>
             <div class="submit">
-            <a href="#" onClick="remake_table(); return false;">Submit</a>
+                <a href="#" onClick="make_table({}, true); return false;">Submit</a>
             </div>
         </span>
     </div>
@@ -21,22 +21,15 @@
     <script src="shared.js"></script>
     <script src="libs/fetch.js"></script>
     <script>
-    make_as_of();
-    // Read the various settings, then call make_table.
-    function remake_table() {
-        var date = getDate("date");
-
-        make_table(date, true);
-    }
-
-    function make_table(date, push_state) {
+    function make_table(state, push_state) {
+        let date = state.date || getDate("date");
         fetch(BASE_URL + "/get_tabular", make_request({ date: date })).then(function(response) {
             response.json().then(function(data) {
-                set_date(date);
+                set_date("date", date);
                 populate_table(data);
 
                 if (push_state) {
-                    push_state_to_history(keys, [data.date]);
+                    push_state_to_history({ date: data.date });
                 }
             });
         }, function(err) {
@@ -102,19 +95,12 @@
         return 1;
     }
 
-    var keys = ["date"];
-
     // Respond to back/forwards properly.
-    window.onpopstate = function(ev) {
-        var state = ev.state;
-        if (!dispatch_on_state(make_table, state, keys)) {
-            if (!dispatch_on_params(make_table, keys)) {
-                document.getElementById("table").innerHTML = "";
-            }
-        }
+    window.onpopstate = function() {
+        dispatch_on_params(make_table);
     };
 
     // Load the page from a URL.
-    dispatch_on_params(make_table, keys);
+    dispatch_on_params(make_table);
     </script>
 </html>


### PR DESCRIPTION
We update state handling to no longer keep keys and values separate,
instead everything is dumped into an object and the key value pairs are
used in all functions.

remake_* functions are folded into the parent via state.prop ||
get_prop(..) on input handling. This is cleaner, and makes maintenance
easier, since there is less Javascript.

Fixes #122.