### PR TITLE
Expose fields on Recording

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -97,6 +97,14 @@ impl Recording {
             rss: 0,
         }
     }
+    
+    pub fn get_time(&self) -> f64 {
+        self.time
+    }
+    
+    pub fn get_rss(&self) -> u64 {
+        self.rss
+    }
 
     fn record(&mut self, phase: Option<&Pass>) {
         if let Some(phase) = phase {

--- a/src/server.rs
+++ b/src/server.rs
@@ -86,8 +86,8 @@ impl DateData {
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Recording {
     #[serde(with = "util::round_float")]
-    time: f64,
-    rss: u64,
+    pub time: f64,
+    pub rss: u64,
 }
 
 impl Recording {
@@ -96,14 +96,6 @@ impl Recording {
             time: 0.0,
             rss: 0,
         }
-    }
-    
-    pub fn get_time(&self) -> f64 {
-        self.time
-    }
-    
-    pub fn get_rss(&self) -> u64 {
-        self.rss
     }
 
     fn record(&mut self, phase: Option<&Pass>) {


### PR DESCRIPTION
For consumers of the perf API, the fields of `Recording` are vital to actually extract any results (e.g., #132).