### PR TITLE
Use -is-final-crate to indicate the final crate.

### DIFF
--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -161,7 +161,11 @@ impl<'sysroot> CargoProcess<'sysroot> {
         if self.nll {
             cmd.arg("-Znll");
         }
-        cmd.arg("-Ztime-passes");
+        // -is-final-crate is not a valid rustc arg. But rustc-fake recognizes
+        // it, uses it as an indicator that the final crate is being compiled
+        // -- because `cargo rustc` only passes arguments in this position in
+        // that case -- and then strips it out before invoking the real rustc.
+        cmd.arg("-is-final-crate");
         cmd.args(&self.rustc_args);
 
         debug!("run_rustc: {:?}", cmd);


### PR DESCRIPTION
Current -Ztime-passes is used, but it's misleading because it's treated
in a special way by fake-rustc. In contrast, -is-final-crate is not a
valid rust argument, and so it's more obvious that something unusual is
going on.

The patch also tweaks the exec() function in rustc-fake to be clearer --
putting cmd.exec() inside panic!() is rather non-obvious.