### PR TITLE
Use separators when printing large numbers.

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -43,7 +43,7 @@
     function add_datum_fields(datum) {
         let html = "";
         if (datum) {
-            html += "<td>" + datum.toFixed(2) + "</td>";
+            html += "<td>" + datum.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2}) + "</td>";
         } else {
             html += "<td>-</td>";
         }

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -138,8 +138,9 @@
                         let commit = this.point.commit.substr(0, 10);
                         let y_axis = crate_name.startsWith("Summary") ? summaryYAxis : yAxis;
                         return "<b>" + date.toLocaleString() + " - " + commit + "</b>" +
-                            "<br>" + this.series.name + ": " + this.point.absolute.toFixed(2) + " " +
-                            y_axis.toLowerCase() + " (" +
+                            "<br>" + this.series.name + ": " +
+                            this.point.absolute.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2}) +
+                            " " + y_axis.toLowerCase() + " (" +
                             this.point.percent.toFixed(2) + "% from start)";
                     },
                 },


### PR DESCRIPTION
Because 94,266,333,477.00 is much easier to read than 94266333477.00.