### PR TITLE
Add `profile_eprintln` subcommand.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -98,6 +98,14 @@ All this is the same as for the `bench_local` subcommand, except that
   a `msout` prefix. Those files can be processed with `ms_print` or viewed with
   `massif-visualizer`; the latter is recommended, though it sometimes fails to
   read output files that `ms_print` can handle.
+- `profile_eprintln`: Profile with `eprintln!` statements. Sometimes it is
+  useful to do ad hoc profiling by inserting `eprintln!` statements into rustc,
+  e.g. to count how often particular paths are hit, or to see what values
+  particular expressions have each time they are executed. This subcommand is
+  for this use case. The output of these `eprintln!` statements (and everything
+  else written to `stderr`) is written to files with an `eprintln` prefix.
+  Those files can be post-processed in any appropriate fashion; `sort $FILE |
+  uniq -c` is one possibility.
 
 ## @bors try builds
 

--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -121,6 +121,13 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
+            "eprintln" => {
+                let mut cmd = Command::new(&rustc);
+                cmd.args(&args);
+
+                assert!(cmd.status().expect("failed to spawn").success());
+            }
+
             _ => {
                 panic!("unknown wrapper: {}", wrapper);
             }

--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -100,6 +100,7 @@ pub enum Profiler {
     Callgrind,
     DHAT,
     Massif,
+    Eprintln,
 }
 
 impl Profiler {
@@ -112,6 +113,7 @@ impl Profiler {
             Profiler::Callgrind => "callgrind",
             Profiler::DHAT => "dhat",
             Profiler::Massif => "massif",
+            Profiler::Eprintln => "eprintln",
         }
     }
 }
@@ -573,6 +575,15 @@ impl Benchmark {
                     fs::copy(&tmp_msout_file, &msout_file)?;
                 }
 
+                // eprintln! statements writes their output to stderr. We copy
+                // that output into a file in the output dir.
+                Profiler::Eprintln => {
+                    let eprintln_file = filepath(output_dir, &out_file("eprintln"));
+
+                    let mut f = File::create(eprintln_file)?;
+                    f.write_all(&output.stderr)?;
+                    f.flush()?;
+                }
             }
         }
         Ok(())

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -281,6 +281,12 @@ fn main_result() -> Result<i32, Error> {
            (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
            (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
        )
+       (@subcommand profile_eprintln =>
+           (about: "profile a local rustc augmented with eprintln! statements")
+           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
+           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
+           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
+       )
        (@subcommand remove_errs =>
            (about: "remove errored data")
        )
@@ -400,6 +406,9 @@ fn main_result() -> Result<i32, Error> {
         }
         ("profile_massif", Some(sub_m)) => {
             profile(Profiler::Massif, sub_m, &get_out_dir(), &benchmarks)
+        }
+        ("profile_eprintln", Some(sub_m)) => {
+            profile(Profiler::Eprintln, sub_m, &get_out_dir(), &benchmarks)
         }
         ("remove_errs", Some(_)) => {
             for commit in &get_commits()? {


### PR DESCRIPTION
This subcommand captures stderr. This is useful for profiling a rustc
that has had ad hoc `eprintln!` statements added to it.

(This might seem like a weird one, but this kind of profiling is something I do frequently. Until now I was using the `profile_dhat` subcommand because it also captures stderr. But that is (a) super slow, because DHAT is super slow, and (b) includes all of DHAT's output mixed in with the `eprintln!` output. So I think it's worth having as a separate subcommand. I have already used it once today since I implemented it.)