### PR TITLE
Switch to messagepack for POST response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,14 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -916,6 +924,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rust_sysroot"
 version = "0.1.0"
 source = "git+https://github.com/Mark-Simulacrum/bisect-rust.git#1970c7600f6389a375ad1b923e40cdedc7b3b605"
@@ -1065,6 +1092,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sysroot 0.1.0 (git+https://github.com/Mark-Simulacrum/bisect-rust.git)",
  "serde 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1580,6 +1608,7 @@ dependencies = [
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
@@ -1605,6 +1634,8 @@ dependencies = [
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
 "checksum reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "241faa9a8ca28a03cbbb9815a5d085f271d4c0168a19181f106aa93240c22ddb"
+"checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
+"checksum rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "011e1d58446e9fa3af7cdc1fb91295b10621d3ac4cb3a85cc86385ee9ca50cd3"
 "checksum rust_sysroot 0.1.0 (git+https://github.com/Mark-Simulacrum/bisect-rust.git)" = "<none>"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"

--- a/site/Cargo.toml
+++ b/site/Cargo.toml
@@ -17,6 +17,7 @@ url = "1.5"
 antidote = "1.0"
 chrono = "0.4"
 flate2 = "1.0.1"
+rmp-serde = "0.13.7"
 
 [dependencies.collector]
 path = "../collector"

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -104,9 +104,9 @@ pub mod graph {
         pub benchmark: String,
         pub commit: String,
         pub prev_commit: Option<String>,
-        pub absolute: f64,
-        pub percent: f64,
-        pub y: f64,
+        pub absolute: f32,
+        pub percent: f32,
+        pub y: f32,
         pub x: u64,
     }
 
@@ -114,7 +114,7 @@ pub mod graph {
     pub struct Response {
         /// Crate -> Benchmark -> [GraphData]
         pub benchmarks: HashMap<String, HashMap<String, Vec<GraphData>>>,
-        pub max: HashMap<String, f64>,
+        pub max: HashMap<String, f32>,
     }
 }
 

--- a/site/src/lib.rs
+++ b/site/src/lib.rs
@@ -23,6 +23,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate rmp_serde;
 extern crate url;
 
 mod errors {

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -126,6 +126,7 @@ pub fn handle_graph(body: graph::Request, data: &InputData) -> ServerResult<grap
             let mut base_compile = false;
             let mut trivial = false;
             for (name, run, value) in runs.clone() {
+                let value = value as f32;
                 if run.state.is_base_compile() {
                     base_compile = true;
                 } else if run.is_trivial() {
@@ -135,7 +136,7 @@ pub fn handle_graph(body: graph::Request, data: &InputData) -> ServerResult<grap
                 let mut entry = entry
                     .entry(name)
                     .or_insert_with(|| Vec::<graph::GraphData>::with_capacity(elements));
-                let first = entry.first().map(|d| d.absolute);
+                let first = entry.first().map(|d| d.absolute as f32);
                 let percent = first.map_or(0.0, |f| (value - f) / f * 100.0);
                 entry.push(graph::GraphData {
                     benchmark: run.state.name(),
@@ -161,7 +162,7 @@ pub fn handle_graph(body: graph::Request, data: &InputData) -> ServerResult<grap
             }
         }
         for (&(release, check, ref state), values) in &summary_points {
-            let value = values.iter().sum::<f64>() / (values.len() as f64);
+            let value = (values.iter().sum::<f64>() as f32) / (values.len() as f32);
             if !release && !check && state.is_base_compile() && initial_base_compile.is_none() {
                 initial_base_compile = Some(value);
             }
@@ -184,7 +185,7 @@ pub fn handle_graph(body: graph::Request, data: &InputData) -> ServerResult<grap
                 .entry(String::from("Summary") + appendix)
                 .or_insert_with(HashMap::new);
             let entry = summary.entry(state.name()).or_insert_with(Vec::new);
-            let value = values.iter().sum::<f64>() / (values.len() as f64);
+            let value = (values.iter().sum::<f64>() as f32) / (values.len() as f32);
             let value = value / if release {
                 initial_release_base_compile.unwrap()
             } else if check {
@@ -192,7 +193,7 @@ pub fn handle_graph(body: graph::Request, data: &InputData) -> ServerResult<grap
             } else {
                 initial_base_compile.unwrap()
             };
-            let first = entry.first().map(|d: &graph::GraphData| d.absolute);
+            let first = entry.first().map(|d: &graph::GraphData| d.absolute as f32);
             let percent = first.map_or(0.0, |f| (value - f) / f * 100.0);
             entry.push(graph::GraphData {
                 benchmark: state.name(),
@@ -210,13 +211,13 @@ pub fn handle_graph(body: graph::Request, data: &InputData) -> ServerResult<grap
     let mut maxes = HashMap::with_capacity(result.len());
     for (ref crate_name, ref benchmarks) in &result {
         let name = crate_name.replace("-opt", "").replace("-check", "");
-        let mut max = 0.0f64;
+        let mut max = 0.0f32;
         for points in benchmarks.values() {
             for point in points {
                 max = max.max(point.y);
             }
         }
-        let max = maxes.get(&name).cloned().unwrap_or(0.0f64).max(max);
+        let max = maxes.get(&name).cloned().unwrap_or(0.0f32).max(max);
         maxes.insert(name, max);
     }
 

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -26,6 +26,7 @@
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
     </a>
 </body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="libs/highcharts.js"></script>
     <script src="libs/fetch.js"></script>
     <script src="shared.js"></script>

--- a/site/static/shared.js
+++ b/site/static/shared.js
@@ -227,7 +227,9 @@ function make_request(path, body) {
         body: JSON.stringify(body),
         mode: "cors"
     }).then(response => {
-        return response.clone().json().catch(() => {
+        return response.clone().arrayBuffer().then((arrayBuffer) => {
+            return msgpack.decode(new Uint8Array(arrayBuffer))
+        }).catch(() => {
             return response.text().then(data => alert(data));
         });
     }, err => {


### PR DESCRIPTION
Switched the encoding of large responses to MsgPack so we can save data primarily on floats. Encoding is also faster as we don't need to make them decimal.

Additionally, changed the response in graph data from double precision floats to single precision, as we can't observe the difference with eye.

Results:

Response size: 3.8MB -> 1.8MB
Computing time: 1164ms -> 724ms