### PR TITLE
Give more control over what is profiled

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -110,6 +110,18 @@ All this is the same as for the `bench_local` subcommand, except that
   be post-processed in any appropriate fashion; `sort $FILE | uniq -c` is one
   possibility.
 
+## Profiling options
+
+`--builds $BUILDS` can be used to select what kind of builds are profiled. The
+default is `Debug`. The possible choices are one or more (comma-separated) of
+`Check`, `Debug`, `Opt`, and `All`.
+
+`--runs $RUNS` can be used to select what profiling runs are done for each
+build. The default is `Clean`. The possible choices are one or more
+(comma-separated) of `Clean`, `Nll`, `BaseIncr`, `CleanIncr`, `PatchedIncrs`,
+and `All`. Note that `BaseIncr` is always run (even if not requested) if either
+of `CleanIncr` or `PatchedIncrs` are run.
+
 ## @bors try builds
 
 Alternatively, you can ping `simulacrum` on IRC to run the benchmarks on the server for a try build.

--- a/collector/README.md
+++ b/collector/README.md
@@ -77,38 +77,38 @@ enough.
 To profile local builds:
 ```
 RUST_LOG=info ./target/release/collector --output-repo $OUTPUT_DIR \
-    $PROFILE_CMD --rustc $RUSTC --cargo $CARGO $ID
+    profile $PROFILER --rustc $RUSTC --cargo $CARGO $ID
 ```
 
 All this is the same as for the `bench_local` subcommand, except that
-`$PROFILE_CMD` is one of the following.
-- `profile_time_passes`: Profile with rustc's `-Ztime-passes`. Output is
-  written to files with a `Ztp` prefix.
-- `profile_perf_record`: Profile with `perf-record`. Output is written to
-  files with a `perf` prefix. Those files can be read with `perf-report` and
-  other similar `perf` commands.
-- `profile_cachegrind`: Profile with Cachegrind. Raw output is written to
-  files with a `cgout` prefix; human-readable output is written to files with a
-  `cgann` prefix.
-- `profile_callgrind`: Profile with Callgrind. Raw output is written to files
-  with a `clgout` prefix; human-readable output is written to files with a
-  `clgann` prefix.
-- `profile_dhat`: Profile with DHAT. This may require a rustc configured with
+`$PROFILER` is one of the following.
+- `time-passes`: Profile with rustc's `-Ztime-passes`. Output is written to
+  files with a `Ztp` prefix.
+- `perf-record`: Profile with `perf-record`. Output is written to files with a
+  `perf` prefix. Those files can be read with `perf-report` and other similar
+  `perf` commands.
+- `cachegrind`: Profile with Cachegrind. Raw output is written to files with a
+  `cgout` prefix; human-readable output is written to files with a `cgann`
+  prefix.
+- `callgrind`: Profile with Callgrind. Raw output is written to files with a
+  `clgout` prefix; human-readable output is written to files with a `clgann`
+  prefix.
+- `dhat`: Profile with DHAT. This may require a rustc configured with
   `use-jemalloc = false` to work well. Output is written to files with a `dhat`
   prefix.
-- `profile_massif`: Profile with Massif. This may require a rustc configured
-  with `use-jemalloc = false` to work well. Raw output is written to files with
-  a `msout` prefix. Those files can be processed with `ms_print` or viewed with
+- `massif`: Profile with Massif. This may require a rustc configured with
+  `use-jemalloc = false` to work well. Raw output is written to files with a
+  `msout` prefix. Those files can be processed with `ms_print` or viewed with
   `massif-visualizer`; the latter is recommended, though it sometimes fails to
   read output files that `ms_print` can handle.
-- `profile_eprintln`: Profile with `eprintln!` statements. Sometimes it is
-  useful to do ad hoc profiling by inserting `eprintln!` statements into rustc,
-  e.g. to count how often particular paths are hit, or to see what values
-  particular expressions have each time they are executed. This subcommand is
-  for this use case. The output of these `eprintln!` statements (and everything
-  else written to `stderr`) is written to files with an `eprintln` prefix.
-  Those files can be post-processed in any appropriate fashion; `sort $FILE |
-  uniq -c` is one possibility.
+- `eprintln`: Profile with `eprintln!` statements. Sometimes it is useful to do
+  ad hoc profiling by inserting `eprintln!` statements into rustc, e.g. to
+  count how often particular paths are hit, or to see what values particular
+  expressions have each time they are executed. This subcommand is for this use
+  case. The output of these `eprintln!` statements (and everything else written
+  to `stderr`) is written to files with an `eprintln` prefix. Those files can
+  be post-processed in any appropriate fashion; `sort $FILE | uniq -c` is one
+  possibility.
 
 ## @bors try builds
 

--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -103,7 +103,32 @@ pub enum Profiler {
     Eprintln,
 }
 
+#[derive(Fail, PartialEq, Eq, Debug)]
+pub enum FromNameError {
+    #[fail(display = "'perf-stat' cannot be used as the profiler")]
+    PerfStat,
+    #[fail(display = "'{:?}' is not a known profiler", _0)]
+    UnknownProfiler(String),
+}
+
 impl Profiler {
+    pub fn from_name(name: &str) -> Result<Profiler, FromNameError> {
+        match name {
+            // Even though `PerfStat` is a valid `Profiler` value, "perf-stat"
+            // is rejected because it can't be used with the `profiler`
+            // subcommand. (It's used with `bench_local` instead.)
+            "perf-stat" => Err(FromNameError::PerfStat),
+            "time-passes" => Ok(Profiler::TimePasses),
+            "perf-record" => Ok(Profiler::PerfRecord),
+            "cachegrind" => Ok(Profiler::Cachegrind),
+            "callgrind" => Ok(Profiler::Callgrind),
+            "dhat" => Ok(Profiler::DHAT),
+            "massif" => Ok(Profiler::Massif),
+            "eprintln" => Ok(Profiler::Eprintln),
+            _ => Err(FromNameError::UnknownProfiler(name.to_string())),
+        }
+    }
+
     fn name(&self) -> &'static str {
         match self {
             Profiler::PerfStat => "perf-stat",

--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -84,11 +84,79 @@ pub struct Benchmark {
     config: BenchmarkConfig,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum BuildKind {
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum BuildKind {
     Check,
     Debug,
     Opt
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RunKind {
+    Clean,
+    Nll,
+    BaseIncr,
+    CleanIncr,
+    PatchedIncrs,
+}
+
+#[derive(Fail, PartialEq, Eq, Debug)]
+pub enum KindError {
+    #[fail(display = "'{:?}' is not a known {} kind", _1, _0)]
+    UnknownKind(&'static str, String),
+}
+
+// How the --builds arg maps to BuildKinds.
+const STRINGS_AND_BUILD_KINDS: &'static [(&'static str, BuildKind)] = &[
+    ("Check", BuildKind::Check),
+    ("Debug", BuildKind::Debug),
+    ("Opt", BuildKind::Opt),
+];
+
+// How the --runs arg maps to RunKinds.
+const STRINGS_AND_RUN_KINDS: &'static [(&'static str, RunKind)] = &[
+    ("Clean", RunKind::Clean),
+    ("Nll", RunKind::Nll),
+    ("BaseIncr", RunKind::BaseIncr),
+    ("CleanIncr", RunKind::CleanIncr),
+    ("PatchedIncrs", RunKind::PatchedIncrs),
+];
+
+pub fn build_kinds_from_arg(arg: &str) -> Result<Vec<BuildKind>, KindError> {
+    kinds_from_arg(STRINGS_AND_BUILD_KINDS, arg)
+}
+
+pub fn run_kinds_from_arg(arg: &str) -> Result<Vec<RunKind>, KindError> {
+    kinds_from_arg(STRINGS_AND_RUN_KINDS, arg)
+}
+
+// Converts a comma-separated list of kind names to a vector of kinds with no
+// duplicates.
+fn kinds_from_arg<K>(strings_and_kinds: &[(&str, K)], arg: &str)
+                     -> Result<Vec<K>, KindError>
+    where K: Copy + Eq + ::std::hash::Hash
+{
+    let mut kind_set = HashSet::new();
+
+    for s in arg.split(',') {
+        if let Some((_s, k)) = strings_and_kinds.iter().find(|(str, _k)| s == *str) {
+            kind_set.insert(k);
+        } else if s == "All" {
+            for (_, k) in strings_and_kinds.iter() {
+                kind_set.insert(k);
+            }
+        } else {
+            return Err(KindError::UnknownKind("build", s.to_string()))
+        }
+    }
+
+    let mut v = vec![];
+    for (_s, k) in strings_and_kinds.iter() {
+        if kind_set.contains(k) {
+            v.push(*k);
+        }
+    }
+    Ok(v)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -469,6 +537,8 @@ impl Benchmark {
     pub fn profile(
         &self,
         profiler: Profiler,
+        build_kinds: &Option<Vec<BuildKind>>,
+        run_kinds: &Option<Vec<RunKind>>,
         output_dir: &Path,
         rustc_path: &Path,
         cargo_path: &Path,
@@ -479,13 +549,12 @@ impl Benchmark {
             bail!("disabled benchmark");
         }
 
-        // XXX: Currently we profile a single "clean" (from scratch),
-        // non-incremental, Debug build. This may change in the future.
-
-        let build_kinds = vec![BuildKind::Debug];
+        // Fall back to defaults if the kinds weren't specified.
+        let build_kinds = build_kinds.clone().unwrap_or(vec![BuildKind::Debug]);
+        let run_kinds = run_kinds.clone().unwrap_or(vec![RunKind::Clean]);
 
         for build_kind in build_kinds {
-            info!("Profiling {} with build kind: {:?}", self.name, build_kind);
+            info!("Profiling {}: {:?} + {:?}", self.name, build_kind, run_kinds);
 
             // Build everything, including all dependent crates, in a temp dir.
             let prep_dir = self.make_temp_dir(&self.path)?;
@@ -494,120 +563,174 @@ impl Benchmark {
 
             let timing_dir = self.make_temp_dir(prep_dir.path())?;
 
+            let process_output = |output: process::Output, run_kind: &str| -> Result<(), Error> {
+                // Produce a name of the form $PREFIX-$ID-$BENCHMARK-$BUILDKIND-$RUNKIND.
+                let out_file = |prefix: &str| -> String {
+                    format!("{}-{}-{}-{:?}-{}", prefix, id, &self.name, build_kind, run_kind)
+                };
+
+                // Combine a dir and a file.
+                let filepath = |dir: &Path, file: &str| {
+                    let mut path = dir.to_path_buf();
+                    path.push(file);
+                    path
+                };
+
+                match profiler {
+                    Profiler::PerfStat => {
+                        panic!("unexpected profiler");
+                    }
+
+                    // -Ztime-passes writes its output to stdout. We copy that
+                    // output into a file in the output dir.
+                    Profiler::TimePasses => {
+                        let ztp_file = filepath(output_dir, &out_file("Ztp"));
+
+                        let mut f = File::create(ztp_file)?;
+                        f.write_all(&output.stdout)?;
+                        f.flush()?;
+                    }
+
+                    // perf-record produces (via rustc-fake) a data file called
+                    // 'perf'. We copy it from the temp dir to the output dir,
+                    // giving it a new name in the process.
+                    Profiler::PerfRecord => {
+                        let tmp_perf_file = filepath(timing_dir.as_ref(), "perf");
+                        let perf_file = filepath(output_dir, &out_file("perf"));
+
+                        fs::copy(&tmp_perf_file, &perf_file)?;
+                    }
+
+                    // Cachegrind produces (via rustc-fake) a data file called
+                    // 'cgout'. We copy it from the temp dir to the output dir,
+                    // giving it a new name in the process, and then
+                    // post-process it to produce another data file in the
+                    // output dir.
+                    Profiler::Cachegrind => {
+                        let tmp_cgout_file = filepath(timing_dir.as_ref(), "cgout");
+                        let cgout_file = filepath(output_dir, &out_file("cgout"));
+                        let cgann_file = filepath(output_dir, &out_file("cgann"));
+
+                        fs::copy(&tmp_cgout_file, &cgout_file)?;
+
+                        let mut cg_annotate_cmd = Command::new("cg_annotate");
+                        cg_annotate_cmd
+                            .arg("--auto=yes")
+                            .arg(&cgout_file);
+                        let output = cg_annotate_cmd.output()?;
+
+                        let mut f = File::create(cgann_file)?;
+                        f.write_all(&output.stdout)?;
+                        f.flush()?;
+                    }
+
+                    // Callgrind produces (via rustc-fake) a data file called
+                    // 'clgout'. We copy it from the temp dir to the output
+                    // dir, giving it a new name in the process, and then
+                    // post-process it to produce another data file in the
+                    // output dir.
+                    Profiler::Callgrind => {
+                        let tmp_clgout_file = filepath(timing_dir.as_ref(), "clgout");
+                        let clgout_file = filepath(output_dir, &out_file("clgout"));
+                        let clgann_file = filepath(output_dir, &out_file("clgann"));
+
+                        fs::copy(&tmp_clgout_file, &clgout_file)?;
+
+                        let mut clg_annotate_cmd = Command::new("callgrind_annotate");
+                        clg_annotate_cmd
+                            .arg("--auto=yes")
+                            .arg(&clgout_file);
+                        let output = clg_annotate_cmd.output()?;
+
+                        let mut f = File::create(clgann_file)?;
+                        f.write_all(&output.stdout)?;
+                        f.flush()?;
+                    }
+
+                    // DHAT writes its output to stderr. We copy that output
+                    // into a file in the output dir.
+                    Profiler::DHAT => {
+                        let dhat_file = filepath(output_dir, &out_file("dhat"));
+
+                        let mut f = File::create(dhat_file)?;
+                        f.write_all(&output.stderr)?;
+                        f.flush()?;
+                    }
+
+                    // Massif produces (via rustc-fake) a data file called
+                    // 'msout'. We copy it from the temp dir to the output dir,
+                    // giving it a new name in the process.
+                    Profiler::Massif => {
+                        let tmp_msout_file = filepath(timing_dir.as_ref(), "msout");
+                        let msout_file = filepath(output_dir, &out_file("msout"));
+
+                        fs::copy(&tmp_msout_file, &msout_file)?;
+                    }
+
+                    // eprintln! statements writes their output to stderr. We
+                    // copy that output into a file in the output dir.
+                    Profiler::Eprintln => {
+                        let eprintln_file = filepath(output_dir, &out_file("eprintln"));
+
+                        let mut f = File::create(eprintln_file)?;
+                        f.write_all(&output.stderr)?;
+                        f.flush()?;
+                    }
+                }
+                Ok(())
+            };
+
             // A full non-incremental build.
-            let output = self.mk_cargo_process(rustc_path, cargo_path, build_kind)
-                .profiler(profiler)
-                .run_rustc(timing_dir.path())?;
+            if run_kinds.contains(&RunKind::Clean) {
+                let clean = self.mk_cargo_process(rustc_path, cargo_path, build_kind)
+                    .profiler(profiler)
+                    .run_rustc(timing_dir.path())?;
+                process_output(clean, "Clean")?;
+            }
 
-            // Produce a name of the form $PREFIX-$ID-$BENCHMARK.
-            let out_file = |prefix: &str| -> String {
-                format!("{}-{}-{}", prefix, id, &self.name)
-            };
+            // A full non-incremental build with NLL enabled.
+            if run_kinds.contains(&RunKind::Nll) && self.config.nll {
+                let nll = self.mk_cargo_process(rustc_path, cargo_path, build_kind)
+                    .profiler(profiler)
+                    .nll(true)
+                    .run_rustc(timing_dir.path())?;
+                process_output(nll, "Nll")?;
+            }
 
-            // Combine a dir and a file.
-            let filepath = |dir: &Path, file: &str| {
-                let mut path = dir.to_path_buf();
-                path.push(file);
-                path
-            };
+            // An incremental build from scratch (slowest incremental case).
+            // This is required for any subsequent incremental builds.
+            if run_kinds.contains(&RunKind::BaseIncr) ||
+               run_kinds.contains(&RunKind::CleanIncr) ||
+               run_kinds.contains(&RunKind::PatchedIncrs) {
+                let base_incr = self.mk_cargo_process(rustc_path, cargo_path, build_kind)
+                    .profiler(profiler)
+                    .incremental(true)
+                    .run_rustc(timing_dir.path())?;
+                process_output(base_incr, "BaseIncr")?;
+            }
 
-            match profiler {
-                Profiler::PerfStat => {
-                    panic!("unexpected profiler");
-                }
+            // An incremental build with no changes (fastest incremental case).
+            if run_kinds.contains(&RunKind::CleanIncr) {
+                let clean_incr = self.mk_cargo_process(rustc_path, cargo_path, build_kind)
+                    .profiler(profiler)
+                    .incremental(true)
+                    .run_rustc(timing_dir.path())?;
+                process_output(clean_incr, "CleanIncr")?;
+            }
 
-                // -Ztime-passes writes its output to stdout. We copy that
-                // output into a file in the output dir.
-                Profiler::TimePasses => {
-                    let ztp_file = filepath(output_dir, &out_file("Ztp"));
+            if run_kinds.contains(&RunKind::PatchedIncrs) {
+                for (i, patch) in self.patches.iter().enumerate() {
+                    debug!("applying patch {}", patch.name);
+                    patch.apply(timing_dir.path()).map_err(|s| err_msg(s))?;
 
-                    let mut f = File::create(ztp_file)?;
-                    f.write_all(&output.stdout)?;
-                    f.flush()?;
-                }
-
-                // perf-record produces (via rustc-fake) a data file called
-                // 'perf'. We copy it from the temp dir to the output dir,
-                // giving it a new name in the process.
-                Profiler::PerfRecord => {
-                    let tmp_perf_file = filepath(timing_dir.as_ref(), "perf");
-                    let perf_file = filepath(output_dir, &out_file("perf"));
-
-                    fs::copy(&tmp_perf_file, &perf_file)?;
-                }
-
-                // Cachegrind produces (via rustc-fake) a data file called
-                // 'cgout'. We copy it from the temp dir to the output dir,
-                // giving it a new name in the process, and then post-process
-                // it to produce another data file in the output dir.
-                Profiler::Cachegrind => {
-                    let tmp_cgout_file = filepath(timing_dir.as_ref(), "cgout");
-                    let cgout_file = filepath(output_dir, &out_file("cgout"));
-                    let cgann_file = filepath(output_dir, &out_file("cgann"));
-
-                    fs::copy(&tmp_cgout_file, &cgout_file)?;
-
-                    let mut cg_annotate_cmd = Command::new("cg_annotate");
-                    cg_annotate_cmd
-                        .arg("--auto=yes")
-                        .arg(&cgout_file);
-                    let output = cg_annotate_cmd.output()?;
-
-                    let mut f = File::create(cgann_file)?;
-                    f.write_all(&output.stdout)?;
-                    f.flush()?;
-                }
-
-                // Callgrind produces (via rustc-fake) a data file called
-                // 'clgout'. We copy it from the temp dir to the output dir,
-                // giving it a new name in the process, and then post-process
-                // it to produce another data file in the output dir.
-                Profiler::Callgrind => {
-                    let tmp_clgout_file = filepath(timing_dir.as_ref(), "clgout");
-                    let clgout_file = filepath(output_dir, &out_file("clgout"));
-                    let clgann_file = filepath(output_dir, &out_file("clgann"));
-
-                    fs::copy(&tmp_clgout_file, &clgout_file)?;
-
-                    let mut clg_annotate_cmd = Command::new("callgrind_annotate");
-                    clg_annotate_cmd
-                        .arg("--auto=yes")
-                        .arg(&clgout_file);
-                    let output = clg_annotate_cmd.output()?;
-
-                    let mut f = File::create(clgann_file)?;
-                    f.write_all(&output.stdout)?;
-                    f.flush()?;
-                }
-
-                // DHAT writes its output to stderr. We copy that output into a
-                // file in the output dir.
-                Profiler::DHAT => {
-                    let dhat_file = filepath(output_dir, &out_file("dhat"));
-
-                    let mut f = File::create(dhat_file)?;
-                    f.write_all(&output.stderr)?;
-                    f.flush()?;
-                }
-
-                // Massif produces (via rustc-fake) a data file called 'msout'.
-                // We copy it from the temp dir to the output dir, giving it a
-                // new name in the process.
-                Profiler::Massif => {
-                    let tmp_msout_file = filepath(timing_dir.as_ref(), "msout");
-                    let msout_file = filepath(output_dir, &out_file("msout"));
-
-                    fs::copy(&tmp_msout_file, &msout_file)?;
-                }
-
-                // eprintln! statements writes their output to stderr. We copy
-                // that output into a file in the output dir.
-                Profiler::Eprintln => {
-                    let eprintln_file = filepath(output_dir, &out_file("eprintln"));
-
-                    let mut f = File::create(eprintln_file)?;
-                    f.write_all(&output.stderr)?;
-                    f.flush()?;
+                    // An incremental build with some changes (realistic
+                    // incremental case).
+                    let patched_incr = self.mk_cargo_process(rustc_path, cargo_path, build_kind)
+                        .profiler(profiler)
+                        .incremental(true)
+                        .run_rustc(timing_dir.path())?;
+                    let run_kind_str = format!("PatchedIncr{}", i);
+                    process_output(patched_incr, &run_kind_str)?;
                 }
             }
         }

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -99,16 +99,16 @@ fn bench_commit(
 }
 
 fn profile(
-    profiler: Profiler,
     matches: &clap::ArgMatches,
     out_dir: &Path,
     benchmarks: &[Benchmark],
 ) -> Result<i32, Error> {
-    info!("Profile with {:?}", profiler);
-
     let rustc = matches.value_of("RUSTC").unwrap();
     let cargo = matches.value_of("CARGO").unwrap();
+    let profiler = Profiler::from_name(matches.value_of("PROFILER").unwrap())?;
     let id = matches.value_of("ID").unwrap();
+
+    info!("Profile with {:?}", profiler);
 
     let rustc_path = PathBuf::from(rustc).canonicalize()?;
     let cargo_path = PathBuf::from(cargo).canonicalize()?;
@@ -246,46 +246,13 @@ fn main_result() -> Result<i32, Error> {
            (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
            (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
        )
-       (@subcommand profile_time_passes =>
-           (about: "profile a local rustc with -Ztime-passes")
+       (@subcommand profile =>
+           (about: "profile a local rustc")
            (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
            (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
-           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
-       )
-       (@subcommand profile_perf_record =>
-           (about: "profile a local rustc with perf-record")
-           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
-           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
-           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
-       )
-       (@subcommand profile_cachegrind =>
-           (about: "profile a local rustc with Cachegrind")
-           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
-           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
-           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
-       )
-       (@subcommand profile_callgrind =>
-           (about: "profile a local rustc with Callgrind")
-           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
-           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
-           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
-       )
-       (@subcommand profile_dhat =>
-           (about: "profile a local rustc with DHAT")
-           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
-           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
-           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
-       )
-       (@subcommand profile_massif =>
-           (about: "profile a local rustc with Massif")
-           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
-           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
-           (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
-       )
-       (@subcommand profile_eprintln =>
-           (about: "profile a local rustc augmented with eprintln! statements")
-           (@arg RUSTC: --rustc +required +takes_value "The path to the local rustc to benchmark")
-           (@arg CARGO: --cargo +required +takes_value "The path to the local Cargo to use")
+           (@arg PROFILER: +required +takes_value
+            "One of: 'time-passes', 'perf-record', 'cachegrind',\n\
+            'callgrind', 'dhat', 'massif', 'eprintln'")
            (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
        )
        (@subcommand remove_errs =>
@@ -387,26 +354,8 @@ fn main_result() -> Result<i32, Error> {
             get_out_repo(true)?.add_commit_data(&result)?;
             Ok(0)
         }
-        ("profile_time_passes", Some(sub_m)) => {
-            profile(Profiler::TimePasses, sub_m, &get_out_dir(), &benchmarks)
-        }
-        ("profile_perf_record", Some(sub_m)) => {
-            profile(Profiler::PerfRecord, sub_m, &get_out_dir(), &benchmarks)
-        }
-        ("profile_cachegrind", Some(sub_m)) => {
-            profile(Profiler::Cachegrind, sub_m, &get_out_dir(), &benchmarks)
-        }
-        ("profile_callgrind", Some(sub_m)) => {
-            profile(Profiler::Callgrind, sub_m, &get_out_dir(), &benchmarks)
-        }
-        ("profile_dhat", Some(sub_m)) => {
-            profile(Profiler::DHAT, sub_m, &get_out_dir(), &benchmarks)
-        }
-        ("profile_massif", Some(sub_m)) => {
-            profile(Profiler::Massif, sub_m, &get_out_dir(), &benchmarks)
-        }
-        ("profile_eprintln", Some(sub_m)) => {
-            profile(Profiler::Eprintln, sub_m, &get_out_dir(), &benchmarks)
+        ("profile", Some(sub_m)) => {
+            profile(sub_m, &get_out_dir(), &benchmarks)
         }
         ("remove_errs", Some(_)) => {
             for commit in &get_commits()? {


### PR DESCRIPTION
Currently you can only profile debug builds doing "clean" runs. This is too restrictive.