### PR TITLE
Remove fetch polyfill

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -30,7 +30,6 @@
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
     </a>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.4/fetch.min.js"></script>
     <script src="shared.js"></script>
     <script>
     function print_date(date) {

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -27,7 +27,6 @@
     </a>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/msgpack-lite/0.1.26/msgpack.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highcharts/6.0.7/highcharts.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.4/fetch.min.js"></script>
     <script src="shared.js"></script>
 
     <script>


### PR DESCRIPTION
Given that we already use arrow functions inside the JS code, it's clear that we don't support IE. Removing the fetch polyfill as well as it's implemented in all evergreen browsers.