### PR TITLE
Allow build/run kind selection in `bench_local`.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -59,6 +59,16 @@ substring of the name of the benchmark(s) you wish to run.
 `--exclude $STR` is the inverse of --filter. `$STR` is a substring of the name
 of the benchmark(s) you wish to skip.
 
+`--builds $BUILDS` can be used to select what kind of builds are profiled. The
+default is `Debug`. The possible choices are one or more (comma-separated) of
+`Check`, `Debug`, `Opt`, and `All`.
+
+`--runs $RUNS` can be used to select what profiling runs are done for each
+build. The default is `Clean`. The possible choices are one or more
+(comma-separated) of `Clean`, `Nll`, `BaseIncr`, `CleanIncr`, `PatchedIncrs`,
+and `All`. Note that `BaseIncr` is always run (even if not requested) if either
+of `CleanIncr` or `PatchedIncrs` are run.
+
 ## Viewing results
 
 Once the benchmarks have been run, start the website:
@@ -109,18 +119,6 @@ All this is the same as for the `bench_local` subcommand, except that
   to `stderr`) is written to files with an `eprintln` prefix. Those files can
   be post-processed in any appropriate fashion; `sort $FILE | uniq -c` is one
   possibility.
-
-## Profiling options
-
-`--builds $BUILDS` can be used to select what kind of builds are profiled. The
-default is `Debug`. The possible choices are one or more (comma-separated) of
-`Check`, `Debug`, `Opt`, and `All`.
-
-`--runs $RUNS` can be used to select what profiling runs are done for each
-build. The default is `Clean`. The possible choices are one or more
-(comma-separated) of `Clean`, `Nll`, `BaseIncr`, `CleanIncr`, `PatchedIncrs`,
-and `All`. Note that `BaseIncr` is always run (even if not requested) if either
-of `CleanIncr` or `PatchedIncrs` are run.
 
 ## @bors try builds
 


### PR DESCRIPTION
This makes it more flexible, like `profile`.

This patch makes `Benchmark::measure()` and `Benchmark::measure()` more
similar to each other. This will make them easier to merge in the
future.

Also, there are now multiple mechanisms for specifying which runs to do;
they should be streamlined in the future.