### PR TITLE
Use a linear y-axis for the dashboard graphs.

### DIFF
--- a/site/static/dashboard.html
+++ b/site/static/dashboard.html
@@ -31,7 +31,7 @@
             },
             yAxis: {
                 title: { text: "Seconds" },
-                type: "logarithmic",
+                min: 0,
             },
             xAxis: {
                 categories: versions,


### PR DESCRIPTION
A log y-axis is appropriate when the data covers multiple orders of
magnitude and/or is exponential in nature. In this case neither of those
two things are true. Furthermore, a log scale distorts the data,
exaggerating compile time reductions and minimizing compile time
regressions, which is undesirable.

So this patch changes to a log scale. It also ensures the y-axis starts
at zero, which is a good choice unless there is a clear reason not to do
so (and in this case there is not).