### PR TITLE
Remove `Mode`.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -60,14 +60,14 @@ substring of the name of the benchmark(s) you wish to run.
 of the benchmark(s) you wish to skip.
 
 `--builds $BUILDS` can be used to select what kind of builds are profiled. The
-default is `Debug`. The possible choices are one or more (comma-separated) of
-`Check`, `Debug`, `Opt`, and `All`.
+possible choices are one or more (comma-separated) of `Check`, `Debug`, `Opt`,
+and `All` (the default).
 
 `--runs $RUNS` can be used to select what profiling runs are done for each
-build. The default is `Clean`. The possible choices are one or more
-(comma-separated) of `Clean`, `Nll`, `BaseIncr`, `CleanIncr`, `PatchedIncrs`,
-and `All`. Note that `BaseIncr` is always run (even if not requested) if either
-of `CleanIncr` or `PatchedIncrs` are run.
+build. The possible choices are one or more (comma-separated) of `Clean`,
+`Nll`, `BaseIncr`, `CleanIncr`, `PatchedIncrs`, and `All` (the default). Note
+that `BaseIncr` is always run (even if not requested) if either of `CleanIncr`
+or `PatchedIncrs` are run.
 
 ## Viewing results
 

--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -21,13 +21,12 @@ use {BuildKind, RunKind};
 
 #[derive(Debug, Copy, Clone)]
 pub struct RustcFeatures {
-    pub incremental: bool,
     pub is_stable: bool,
 }
 
 impl Default for RustcFeatures {
     fn default() -> RustcFeatures {
-        RustcFeatures { incremental: true, is_stable: false }
+        RustcFeatures { is_stable: false }
     }
 }
 
@@ -195,7 +194,7 @@ impl<'a> CargoProcess<'a> {
             .env("CARGO", &self.cargo_path)
             .env(
                 "CARGO_INCREMENTAL",
-                &format!("{}", (self.supports.incremental && self.incremental) as usize),
+                &format!("{}", self.incremental as usize),
             )
             .current_dir(cwd)
             .arg(subcommand)
@@ -452,7 +451,7 @@ impl Benchmark {
                     clean_incr_stats.push(clean_incr);
                 }
 
-                if run_kinds.contains(&RunKind::PatchedIncrs) && supports.incremental {
+                if run_kinds.contains(&RunKind::PatchedIncrs) {
                     for patch in &self.patches {
                         debug!("applying patch {}", patch.name);
                         patch.apply(timing_dir.path()).map_err(|s| err_msg(s))?;
@@ -490,7 +489,7 @@ impl Benchmark {
                 ret.runs.push(process_stats(build_kind, BenchmarkState::IncrementalClean,
                                             clean_incr_stats));
             }
-            if run_kinds.contains(&RunKind::PatchedIncrs) && supports.incremental {
+            if run_kinds.contains(&RunKind::PatchedIncrs) {
                 for (patch, results) in patched_incr_stats {
                     ret.runs.push(process_stats(
                         build_kind,
@@ -523,7 +522,7 @@ impl Benchmark {
             bail!("disabled benchmark");
         }
 
-        let supports = RustcFeatures { is_stable: false, incremental: true };
+        let supports = RustcFeatures { is_stable: false };
 
         for &build_kind in build_kinds {
             info!("Profiling {}: {:?} + {:?}", self.name, build_kind, run_kinds);
@@ -690,7 +689,7 @@ impl Benchmark {
                 process_output(clean_incr, "CleanIncr")?;
             }
 
-            if run_kinds.contains(&RunKind::PatchedIncrs) && supports.incremental {
+            if run_kinds.contains(&RunKind::PatchedIncrs) {
                 for (i, patch) in self.patches.iter().enumerate() {
                     debug!("applying patch {}", patch.name);
                     patch.apply(timing_dir.path()).map_err(|s| err_msg(s))?;

--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -19,17 +19,6 @@ use serde_json;
 
 use {BuildKind, RunKind};
 
-#[derive(Debug, Copy, Clone)]
-pub struct RustcFeatures {
-    pub is_stable: bool,
-}
-
-impl Default for RustcFeatures {
-    fn default() -> RustcFeatures {
-        RustcFeatures { is_stable: false }
-    }
-}
-
 fn command_output(cmd: &mut Command) -> Result<process::Output, Error> {
     trace!("running: {:?}", cmd);
     let output = cmd.output()?;
@@ -309,6 +298,10 @@ impl Benchmark {
         })
     }
 
+    pub fn supports_stable(&self) -> bool {
+        self.config.supports_stable
+    }
+
     fn make_temp_dir(&self, base: &Path) -> Result<TempDir, Error> {
         let tmp_dir = TempDir::new()?;
         let mut cmd = Command::new("cp");
@@ -363,7 +356,6 @@ impl Benchmark {
         rustc_path: &Path,
         cargo_path: &Path,
         iterations: usize,
-        supports: RustcFeatures,
     ) -> Result<CollectedBenchmark, Error> {
         // XXX: measure() and profile() contain a lot of duplicated code and
         // should be combined.
@@ -372,10 +364,6 @@ impl Benchmark {
         if self.config.disabled {
             eprintln!("skipping {}: disabled", self.name);
             bail!("disabled benchmark");
-        }
-
-        if !self.config.supports_stable && supports.is_stable {
-            bail!("disabled -- does not support stable benchmarking");
         }
 
         let has_perf = Command::new("perf").output().is_ok();

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -65,8 +65,12 @@ impl RunKind {
              RunKind::PatchedIncrs]
     }
 
-    fn all_non_incr() -> Vec<RunKind> {
-        vec![RunKind::Clean, RunKind::Nll]
+    fn all_except_nll() -> Vec<RunKind> {
+        vec![RunKind::Clean, RunKind::BaseIncr, RunKind::CleanIncr, RunKind::PatchedIncrs]
+    }
+
+    fn all_non_incr_except_nll() -> Vec<RunKind> {
+        vec![RunKind::Clean]
     }
 }
 
@@ -419,10 +423,11 @@ fn main_result() -> Result<i32, Error> {
                 assert_eq!(id, "beta");
                 true
             };
+            // No NLL runs when testing stable builds.
             let run_kinds = if supports_incremental {
-                RunKind::all()
+                RunKind::all_except_nll()
             } else {
-                RunKind::all_non_incr()
+                RunKind::all_non_incr_except_nll()
             };
             let CommitData { benchmarks: benchmark_data, .. } = bench_commit(
                 None,


### PR DESCRIPTION
`BuildKind` and `Mode` provide overlapping functionality, but `Mode` is
less general, so this patch removes it. As a result, the `BuildKind`
selection logic is now entirely within `main.rs`.

This patch also changes how `build_kinds` and `run_kinds` are specified,
moving the logic entirely into `main.rs`. As part of this, it
changes the default `build_kinds` selection for the `profile` subcommand
from `Debug` to `All`, and the default `run_kinds` selection from
`Check` to `All` -- in both cases to match the `bench_local` subcommand
-- and fixes the documentation accordingly.