### PR TITLE
Improve dashboard's presentation of data series

### DIFF
--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -419,14 +419,8 @@ fn main_result() -> Result<i32, Error> {
             // Remove benchmarks that don't work with a stable compiler.
             benchmarks.retain(|b| b.supports_stable());
 
-            let supports_incremental = if let Some(version) = id.parse::<semver::Version>().ok() {
-                version >= semver::Version::new(1, 24, 0)
-            } else {
-                assert_eq!(id, "beta");
-                true
-            };
             // No NLL runs when testing stable builds.
-            let run_kinds = if supports_incremental {
+            let run_kinds = if collector::version_supports_incremental(id) {
                 RunKind::all_except_nll()
             } else {
                 RunKind::all_non_incr_except_nll()

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -176,27 +176,27 @@ pub struct Run {
 }
 
 impl Run {
-    pub fn is_best_case(&self) -> bool {
-        self.state == BenchmarkState::IncrementalClean
-    }
-
-    pub fn is_worst_case(&self) -> bool {
-        self.state == BenchmarkState::IncrementalStart
-    }
-
-    pub fn is_trivial(&self) -> bool {
-        if let BenchmarkState::IncrementalPatched(ref patch) = self.state {
-            return patch.name == "println";
-        }
-        false
-    }
-
-    pub fn is_non_incremental_clean(&self) -> bool {
+    pub fn is_clean(&self) -> bool {
         self.state == BenchmarkState::Clean
     }
 
     pub fn is_nll(&self) -> bool {
         self.state == BenchmarkState::Nll
+    }
+
+    pub fn is_base_incr(&self) -> bool {
+        self.state == BenchmarkState::IncrementalStart
+    }
+
+    pub fn is_clean_incr(&self) -> bool {
+        self.state == BenchmarkState::IncrementalClean
+    }
+
+    pub fn is_println_incr(&self) -> bool {
+        if let BenchmarkState::IncrementalPatched(ref patch) = self.state {
+            return patch.name == "println";
+        }
+        false
     }
 
     pub fn name(&self) -> String {

--- a/collector/src/lib.rs
+++ b/collector/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate chrono;
 #[macro_use]
 extern crate log;
+extern crate semver;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -421,6 +422,15 @@ where
     D: serde::de::Deserializer<'de>,
 {
     Ok(Option::deserialize(deserializer)?.unwrap_or(0.0))
+}
+
+pub fn version_supports_incremental(version_str: &str) -> bool {
+    if let Some(version) = version_str.parse::<semver::Version>().ok() {
+        version >= semver::Version::new(1, 24, 0)
+    } else {
+        assert!(version_str == "beta" || version_str.starts_with("master"));
+        true
+    }
 }
 
 /// Rounds serialized and deserialized floats to 2 decimal places.

--- a/site/src/api.rs
+++ b/site/src/api.rs
@@ -67,9 +67,10 @@ pub mod info {
 pub mod dashboard {
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     pub struct Cases {
-        pub best_averages: Vec<f64>,
-        pub small_averages: Vec<f64>,
-        pub worst_averages: Vec<f64>,
+        pub clean_averages: Vec<f64>,
+        pub base_incr_averages: Vec<f64>,
+        pub clean_incr_averages: Vec<f64>,
+        pub println_incr_averages: Vec<f64>,
     }
 
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -37,7 +37,7 @@ use failure::Error;
 use git;
 use util::{self, get_repo_path};
 pub use api::{self, nll_dashboard, dashboard, data, days, graph, info, CommitResponse, ServerResult};
-use collector::{Date, Run};
+use collector::{Date, Run, version_supports_incremental};
 use load::{CommitData, InputData};
 use antidote::RwLock;
 
@@ -203,13 +203,15 @@ pub fn handle_dashboard(data: &InputData) -> dashboard::Response {
             }
 
             extend!(check_clean_points, r, r.is_clean() && r.check);
-            extend!(check_base_incr_points, r, r.is_base_incr() && r.check);
-            extend!(check_clean_incr_points, r, r.is_clean_incr() && r.check);
-            extend!(check_println_incr_points, r, r.is_println_incr() && r.check);
             extend!(debug_clean_points, r, r.is_clean() && !r.check && !r.release);
-            extend!(debug_base_incr_points, r, r.is_base_incr() && !r.check && !r.release);
-            extend!(debug_clean_incr_points, r, r.is_clean_incr() && !r.check && !r.release);
-            extend!(debug_println_incr_points, r, r.is_println_incr() && !r.check && !r.release);
+            if version_supports_incremental(version) {
+                extend!(check_base_incr_points, r, r.is_base_incr() && r.check);
+                extend!(check_clean_incr_points, r, r.is_clean_incr() && r.check);
+                extend!(check_println_incr_points, r, r.is_println_incr() && r.check);
+                extend!(debug_base_incr_points, r, r.is_base_incr() && !r.check && !r.release);
+                extend!(debug_clean_incr_points, r, r.is_clean_incr() && !r.check && !r.release);
+                extend!(debug_println_incr_points, r, r.is_println_incr() && !r.check && !r.release);
+            }
         }
 
         check_clean_average.push(average(&check_clean_points));

--- a/site/static/dashboard.html
+++ b/site/static/dashboard.html
@@ -39,19 +39,24 @@
             },
             series: [
                 {
-                    name: "best-case",
+                    name: "clean",
                     animation: false,
-                    data: data.best_averages,
+                    data: data.clean_averages,
                 },
                 {
-                    name: "println-case",
+                    name: "baseline incremental",
                     animation: false,
-                    data: data.small_averages,
+                    data: data.base_incr_averages,
                 },
                 {
-                    name: "worst-case",
+                    name: "clean incremental",
                     animation: false,
-                    data: data.worst_averages,
+                    data: data.clean_incr_averages,
+                },
+                {
+                    name: "patched incremental: println",
+                    animation: false,
+                    data: data.println_incr_averages,
                 },
             ],
         });


### PR DESCRIPTION
This PR renames the existing data series, adds the "clean" series, and improves the transition between the pre- and post-incremental compilation eras.

Here is a screenshot showing the current dashboard:
![dashboard0](https://user-images.githubusercontent.com/1940286/41957134-49ab9db2-7a29-11e8-81bb-8b86e855cf60.png)

Here is a screenshot showing the dashboard with these patches applied:
![dashboard](https://user-images.githubusercontent.com/1940286/41957035-f65b0738-7a28-11e8-85e5-c0ade7fe16ac.png)

I admit that the code in the second patch that identifies pre-incremental versions is hacky; I'm happy to hear alternative ideas.