### PR TITLE
Enable NLL on the servo benchmarks.

### DIFF
--- a/collector/benchmarks/script-servo/perf-config.json
+++ b/collector/benchmarks/script-servo/perf-config.json
@@ -1,6 +1,5 @@
 {
     "cargo_opts": "--no-default-features",
     "cargo_toml": "components/script/Cargo.toml",
-    "runs": 1,
-    "nll": false
+    "runs": 1
 }

--- a/collector/benchmarks/style-servo/perf-config.json
+++ b/collector/benchmarks/style-servo/perf-config.json
@@ -3,6 +3,5 @@
     "cargo_rustc_opts": "--cap-lints=warn",
     "cargo_toml": "components/style/Cargo.toml",
     "runs": 1,
-    "nll": false,
     "supports_stable": true
 }


### PR DESCRIPTION
NLL's slowdown is now only 1.3x for script-servo and 1.4x for
style-servo.

Of the remaining ones that still have NLL disabled:
- `piston-image` and `webrender` don't compile with NLL.
- `html5ever` is 20x slower with NLL. (Still better than `tuple-stress`'s 160x slowdown, though.)

CC @nikomatsakis 