### PR TITLE
Change NLL dashboard labels.

### DIFF
--- a/site/static/nll-dashboard.html
+++ b/site/static/nll-dashboard.html
@@ -56,7 +56,7 @@
 
         // Heading: the two dates, and the time and rss percent changes.
         html += "<thead>";
-        html += "<tr><th>Case</th><th>Clean</th><th>NLL</th><th>%</th></tr>";
+        html += "<tr><th>Benchmark</th><th>clean-check</th><th>nll-check</th><th>%</th></tr>";
         html += "</thead>";
 
         for (point of data.points) {


### PR DESCRIPTION
This change makes the labels consistent with the other views. It also
makes it clear that these are Check builds being shown, not Debug or Opt
builds.