### PR TITLE
Enable NLL for html5ever.

### DIFF
--- a/collector/benchmarks/html5ever/perf-config.json
+++ b/collector/benchmarks/html5ever/perf-config.json
@@ -1,4 +1,3 @@
 {
-    "nll": false,
     "supports_stable": true
 }


### PR DESCRIPTION
NLL causes a 20x slowdown, but that's similar to the `tuple-stress`
slowdown, and much better than the `tuple-stress` slowdown used to be.