### PR TITLE
Document the slow clone updating at startup.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -75,7 +75,9 @@ Once the benchmarks have been run, start the website:
 ```
 ./target/release/site $RUSTC_TIMING     # or $OUTPUT_DIR
 ```
-and navigate to localhost:2346 in a web browser.
+and navigate to localhost:2346 in a web browser. The first time you do this the
+Rust repo is cloned, so it will take a minute or two (or more if you have a
+slow internet connection) before the web server starts up.
 
 Note that all benchmark data processing happens when the website is started. If
 additional benchmark runs subsequently occur you must restart the website to

--- a/site/README.md
+++ b/site/README.md
@@ -43,3 +43,8 @@ It can be run with the following command:
 ```
 cargo run --release data
 ```
+
+The first time you do this the Rust repo is cloned, so it will take a minute or
+two (or more if you have a slow internet connection) before the web server
+starts up.
+

--- a/site/src/load.rs
+++ b/site/src/load.rs
@@ -225,7 +225,9 @@ impl InputData {
         }
 
         let last_date = last_date.expect("No dates found");
+        println!("Updating rust.git clone...");
         let commits = rust_sysroot::get_commits(rust_sysroot::EPOCH_COMMIT, "master").map_err(SyncFailure::new)?;
+        println!("Update of rust.git complete");
 
         Ok(InputData {
             crate_list: crate_list,


### PR DESCRIPTION
Because when the updating is slow, especially the first time it's run,
it's easy to think that something is broken.