### PR TITLE
Add keccak crate

### DIFF
--- a/collector/benchmarks/keccak/Cargo.lock
+++ b/collector/benchmarks/keccak/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "keccak"
+version = "0.1.0"
+

--- a/collector/benchmarks/keccak/Cargo.toml
+++ b/collector/benchmarks/keccak/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "keccak"
+version = "0.1.0"
+authors = ["RustCrypto Developers"]
+license = "CC0-1.0"
+description = "Keccak-f sponge function"
+documentation = "https://docs.rs/keccak"
+repository = "https://github.com/RustCrypto/sponges"
+keywords = ["crypto", "sponge", "keccak-f"]
+categories = ["cryptography", "no-std"]
+
+[features]
+no_unroll = []
+
+[badges]
+travis-ci = { repository = "RustCrypto/sponges" }

--- a/collector/benchmarks/keccak/LICENSE
+++ b/collector/benchmarks/keccak/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/collector/benchmarks/keccak/benches/mod.rs
+++ b/collector/benchmarks/keccak/benches/mod.rs
@@ -1,0 +1,9 @@
+#![feature(test)]
+extern crate keccak;
+extern crate test;
+
+#[bench]
+fn f1600(b: &mut test::Bencher) {
+    let mut data = [0u64; 25];
+    b.iter(|| keccak::f1600(&mut data));
+}

--- a/collector/benchmarks/keccak/src/lib.rs
+++ b/collector/benchmarks/keccak/src/lib.rs
@@ -1,0 +1,194 @@
+//! Keccak [sponge function](https://en.wikipedia.org/wiki/Sponge_function).
+//!
+//! The function code is fully unrolled and is nearly as fast as the Keccak
+//! team's optimized implementation.
+//!
+//! If you are looking for SHA-3 hash functions take a look at [`sha3`][1] and
+//! [`tiny-keccak`][2] crates.
+//!
+//! To disable loop unrolling (e.g. for constraint targets) use `no_unroll`
+//! feature.
+//!
+//! ```
+//! // Test vectors are from KeccakCodePackage
+//! let mut data = [0u64; 25];
+//!
+//! keccak::f1600(&mut data);
+//! assert_eq!(data, [
+//!     0xF1258F7940E1DDE7, 0x84D5CCF933C0478A, 0xD598261EA65AA9EE, 0xBD1547306F80494D,
+//!     0x8B284E056253D057, 0xFF97A42D7F8E6FD4, 0x90FEE5A0A44647C4, 0x8C5BDA0CD6192E76,
+//!     0xAD30A6F71B19059C, 0x30935AB7D08FFC64, 0xEB5AA93F2317D635, 0xA9A6E6260D712103,
+//!     0x81A57C16DBCF555F, 0x43B831CD0347C826, 0x01F22F1A11A5569F, 0x05E5635A21D9AE61,
+//!     0x64BEFEF28CC970F2, 0x613670957BC46611, 0xB87C5A554FD00ECB, 0x8C3EE88A1CCF32C8,
+//!     0x940C7922AE3A2614, 0x1841F924A2C509E4, 0x16F53526E70465C2, 0x75F644E97F30A13B,
+//!     0xEAF1FF7B5CECA249,
+//! ]);
+//!
+//! keccak::f1600(&mut data);
+//! assert_eq!(data, [
+//!     0x2D5C954DF96ECB3C, 0x6A332CD07057B56D, 0x093D8D1270D76B6C, 0x8A20D9B25569D094,
+//!     0x4F9C4F99E5E7F156, 0xF957B9A2DA65FB38, 0x85773DAE1275AF0D, 0xFAF4F247C3D810F7,
+//!     0x1F1B9EE6F79A8759, 0xE4FECC0FEE98B425, 0x68CE61B6B9CE68A1, 0xDEEA66C4BA8F974F,
+//!     0x33C43D836EAFB1F5, 0xE00654042719DBD9, 0x7CF8A9F009831265, 0xFD5449A6BF174743,
+//!     0x97DDAD33D8994B40, 0x48EAD5FC5D0BE774, 0xE3B8C8EE55B7B03C, 0x91A0226E649E42E9,
+//!     0x900E3129E7BADD7B, 0x202A9EC5FAA3CCE8, 0x5B3402464E1C3DB6, 0x609F4E62A44C1059,
+//!     0x20D06CD26A8FBF5C,
+//! ]);
+//! ```
+//!
+//! [1]: https://docs.rs/sha3
+//! [2]: https://docs.rs/tiny-keccak
+#![no_std]
+#![allow(non_upper_case_globals)]
+
+const PLEN: usize = 25;
+
+const RHO: [u32; 24] = [
+    1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 2, 14, 27, 41, 56, 8, 25, 43, 62, 18,
+    39, 61, 20, 44,
+];
+
+const PI: [usize; 24] = [
+    10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4, 15, 23, 19, 13, 12, 2, 20, 14,
+    22, 9, 6, 1,
+];
+
+const RC: [u64; 24] = [
+    0x0000000000000001,
+    0x0000000000008082,
+    0x800000000000808a,
+    0x8000000080008000,
+    0x000000000000808b,
+    0x0000000080000001,
+    0x8000000080008081,
+    0x8000000000008009,
+    0x000000000000008a,
+    0x0000000000000088,
+    0x0000000080008009,
+    0x000000008000000a,
+    0x000000008000808b,
+    0x800000000000008b,
+    0x8000000000008089,
+    0x8000000000008003,
+    0x8000000000008002,
+    0x8000000000000080,
+    0x000000000000800a,
+    0x800000008000000a,
+    0x8000000080008081,
+    0x8000000000008080,
+    0x0000000080000001,
+    0x8000000080008008,
+];
+
+#[cfg(not(feature = "no_unroll"))]
+macro_rules! unroll5 {
+    ($var:ident, $body:block) => {
+        { const $var: usize = 0; $body; }
+        { const $var: usize = 1; $body; }
+        { const $var: usize = 2; $body; }
+        { const $var: usize = 3; $body; }
+        { const $var: usize = 4; $body; }
+    };
+}
+
+#[cfg(feature = "no_unroll")]
+macro_rules! unroll5 {
+    ($var:ident, $body:block) => {
+        for $var in 0..5 $body
+    }
+}
+
+#[cfg(not(feature = "no_unroll"))]
+macro_rules! unroll24 {
+    ($var: ident, $body: block) => {
+        { const $var: usize = 0; $body; }
+        { const $var: usize = 1; $body; }
+        { const $var: usize = 2; $body; }
+        { const $var: usize = 3; $body; }
+        { const $var: usize = 4; $body; }
+        { const $var: usize = 5; $body; }
+        { const $var: usize = 6; $body; }
+        { const $var: usize = 7; $body; }
+        { const $var: usize = 8; $body; }
+        { const $var: usize = 9; $body; }
+        { const $var: usize = 10; $body; }
+        { const $var: usize = 11; $body; }
+        { const $var: usize = 12; $body; }
+        { const $var: usize = 13; $body; }
+        { const $var: usize = 14; $body; }
+        { const $var: usize = 15; $body; }
+        { const $var: usize = 16; $body; }
+        { const $var: usize = 17; $body; }
+        { const $var: usize = 18; $body; }
+        { const $var: usize = 19; $body; }
+        { const $var: usize = 20; $body; }
+        { const $var: usize = 21; $body; }
+        { const $var: usize = 22; $body; }
+        { const $var: usize = 23; $body; }
+    };
+}
+
+#[cfg(feature = "no_unroll")]
+macro_rules! unroll24 {
+    ($var:ident, $body:block) => {
+        for $var in 0..24 $body
+    }
+}
+
+#[allow(unused_assignments)]
+/// Keccak-f[1600] sponge function
+pub fn f1600(a: &mut [u64; PLEN]) {
+    let mut arrays: [[u64; 5]; 24] = [[0; 5]; 24];
+
+    unroll24!(i, {
+        // Theta
+        unroll5!(x, {
+            // This looks useless but it gets way slower without it. I tried
+            // using `mem::uninitialized` for the initialisation of `arrays` but
+            // that also makes it slower, although not by as much as removing
+            // this assignment. Optimisers are weird. Maybe a different version
+            // of LLVM will react differently, so if you see this comment
+            // in the future try deleting this assignment and using uninit
+            // above and see how it affects the benchmarks.
+            arrays[i][x] = 0;
+
+            unroll5!(y, {
+                arrays[i][x] ^= a[5 * y + x];
+            });
+        });
+
+        unroll5!(x, {
+            unroll5!(y, {
+                let t1 = arrays[i][(x + 4) % 5];
+                let t2 = arrays[i][(x + 1) % 5].rotate_left(1);
+                a[5 * y + x] ^= t1 ^ t2;
+            });
+        });
+
+        // Rho and pi
+        let mut last = a[1];
+        unroll24!(x, {
+            arrays[i][0] = a[PI[x]];
+            a[PI[x]] = last.rotate_left(RHO[x]);
+            last = arrays[i][0];
+        });
+
+        // Chi
+        unroll5!(y_step, {
+            let y = 5 * y_step;
+
+            unroll5!(x, {
+                arrays[i][x] = a[y + x];
+            });
+
+            unroll5!(x, {
+                let t1 = !arrays[i][(x + 1) % 5];
+                let t2 = arrays[i][(x + 2) % 5];
+                a[y + x] = arrays[i][x] ^ (t1 & t2);
+            });
+        });
+
+        // Iota
+        a[0] ^= RC[i];
+    });
+}


### PR DESCRIPTION
Quoting @oli-obk:
> The keccak crate is a great benchmark for ridiculous numbers of locals and basic blocks. We should add it to the list of perf tests.

So, let's do that. :) This adds an old version, one that still actually has "ridiculous numbers of locals and basic blocks". Later versions reduced that, also to help with compile-times -- but the old version is a good stress-test, so I think it is the better benchmark.
Concretely, this is an exact copy of https://github.com/RustCrypto/sponges/tree/a417e97a41776a2feee20f98e1d97917b7ad35f0/keccak.

Is there anything else needed, other than adding it in this directory?