### PR TITLE
'cargo build' everything once to update lock file format

### DIFF
--- a/collector/benchmarks/coercions/Cargo.lock
+++ b/collector/benchmarks/coercions/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "issue-32278-big-array-of-strings"
 version = "0.1.0"
 

--- a/collector/benchmarks/deep-vector/Cargo.lock
+++ b/collector/benchmarks/deep-vector/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "issue-20936-deep-vector"
 version = "0.1.0"
 

--- a/collector/benchmarks/futures/Cargo.lock
+++ b/collector/benchmarks/futures/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "futures"
 version = "0.1.0"
 dependencies = [

--- a/collector/benchmarks/helloworld/Cargo.lock
+++ b/collector/benchmarks/helloworld/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "helloworld"
 version = "0.1.0"
 

--- a/collector/benchmarks/inflate/Cargo.lock
+++ b/collector/benchmarks/inflate/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "inflate"
 version = "0.1.0"
 

--- a/collector/benchmarks/style-servo/Cargo.lock
+++ b/collector/benchmarks/style-servo/Cargo.lock
@@ -1,22 +1,3 @@
-[root]
-name = "style_traits"
-version = "0.0.1"
-dependencies = [
- "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "malloc_size_of 0.0.1",
- "malloc_size_of_derive 0.0.1",
- "selectors 0.19.0",
- "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo_arc 0.0.1",
- "servo_atoms 0.0.1",
- "webrender_api 0.52.1 (git+https://github.com/servo/webrender)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
@@ -1070,6 +1051,25 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "style_traits"
+version = "0.0.1"
+dependencies = [
+ "app_units 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "malloc_size_of 0.0.1",
+ "malloc_size_of_derive 0.0.1",
+ "selectors 0.19.0",
+ "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo_arc 0.0.1",
+ "servo_atoms 0.0.1",
+ "webrender_api 0.52.1 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]

--- a/collector/benchmarks/syn/Cargo.lock
+++ b/collector/benchmarks/syn/Cargo.lock
@@ -1,18 +1,3 @@
-[root]
-name = "syn"
-version = "0.11.11"
-dependencies = [
- "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (git+https://github.com/dtolnay/quote)",
- "synom 0.11.3",
- "syntex_pos 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntex_syntax 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "backtrace"
 version = "0.3.3"
@@ -235,6 +220,21 @@ dependencies = [
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+dependencies = [
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (git+https://github.com/dtolnay/quote)",
+ "synom 0.11.3",
+ "syntex_pos 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/collector/benchmarks/tuple-stress/Cargo.lock
+++ b/collector/benchmarks/tuple-stress/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "tuple-stress"
 version = "0.1.0"
 

--- a/collector/benchmarks/unify-linearly/Cargo.lock
+++ b/collector/benchmarks/unify-linearly/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "issue-32062-equality-relations-complexity"
 version = "0.1.0"
 


### PR DESCRIPTION
git kept telling me I have local modifications because doing `cargo build` touches the lockfile. So I propose we change the lockfile format in-tree to avoid that hassle.

The only create that still has a lockfile changing (that I know of) is `crates.io`; doing `cargo build` there changed way more than I was comfortable committing.