### PR TITLE
Tweak the `perf-record` invocation.

### DIFF
--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -49,8 +49,9 @@ fn main() {
                 let has_perf = cmd.output().is_ok();
                 assert!(has_perf);
                 cmd.arg("record")
-                    .arg("--call-graph=dwarf")  // njn: best?
+                    .arg("--call-graph=dwarf")
                     .arg("--output=perf")
+                    .arg("--freq=99")
                     .arg(&rustc)
                     .args(&args);
 


### PR DESCRIPTION
`--freq=99` gives much smaller samples than the default (e.g. 37x
smaller for the case I just tried; 5.3MB rather than 197MB), and it's
what lots of `perf` tutorials suggest.

The patch also removes a stray comment that was left behind in a
previous commit.