### PR TITLE
Change a `cp` command.

### DIFF
--- a/collector/src/bin/rustc-perf-collector/execute.rs
+++ b/collector/src/bin/rustc-perf-collector/execute.rs
@@ -577,12 +577,14 @@ impl Benchmark {
     }
 
     fn make_temp_dir(&self, base: &Path) -> Result<TempDir, Error> {
+        // Appending `.` means we copy just the contents of `base` into
+        // `tmp_dir`, rather than `base` itself.
+        let mut base_dot = base.to_path_buf();
+        base_dot.push(".");
         let tmp_dir = TempDir::new()?;
         let mut cmd = Command::new("cp");
-        cmd.arg("-r")
-            .arg("-T")
-            .arg("--")
-            .arg(base)
+        cmd.arg("-R")
+            .arg(base_dot)
             .arg(tmp_dir.path());
         command_output(&mut cmd).with_context(|_| format!("copying {} to tmp dir", self.name))?;
         Ok(tmp_dir)


### PR DESCRIPTION
The existing command used is `cp -r -T -- src_dir dst_dir`. But
-T doesn't work on Mac.

This commit changes it to `cp -r src_dir/. dst_dir`.

- Appending the `.` has the same effect as -T: copy the contents of
  `src_dir` without copy `src_dir` itself.

- Also, -R is POSIX but -r is not.