### PR TITLE
Bump webpack, webpack-cli, and webpack-dev-server

### DIFF
--- a/collector/benchmarks/webrender/debugger/package.json
+++ b/collector/benchmarks/webrender/debugger/package.json
@@ -30,7 +30,8 @@
     "file-loader": "^1.1.4",
     "vue-loader": "^13.0.5",
     "vue-template-compiler": "^2.4.4",
-    "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.9.1"
+    "webpack": "^4.28.1",
+    "webpack-cli": "^3.2.1",
+    "webpack-dev-server": "^3.1.14"
   }
 }


### PR DESCRIPTION
This avoids https://nvd.nist.gov/vuln/detail/CVE-2018-14732.