### PR TITLE
Fix some "error: missing documentation for macro" errors.

### DIFF
--- a/collector/benchmarks/futures/src/poll.rs
+++ b/collector/benchmarks/futures/src/poll.rs
@@ -1,4 +1,5 @@
 
+/// A macro.
 #[macro_export]
 macro_rules! try_poll {
     ($e:expr) => (match $e {

--- a/collector/benchmarks/hyper/src/header/common/mod.rs
+++ b/collector/benchmarks/hyper/src/header/common/mod.rs
@@ -48,6 +48,7 @@ pub use self::upgrade::{Upgrade, Protocol, ProtocolName};
 pub use self::user_agent::UserAgent;
 pub use self::vary::Vary;
 
+/// A macro.
 #[macro_export]
 macro_rules! bench_header(
     ($name:ident, $ty:ty, $value:expr) => {
@@ -79,6 +80,7 @@ macro_rules! bench_header(
     }
 );
 
+/// A macro.
 #[macro_export]
 macro_rules! __hyper__deref {
     ($from:ty => $to:ty) => {
@@ -98,6 +100,7 @@ macro_rules! __hyper__deref {
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! __hyper__tm {
     ($id:ident, $tm:ident{$($tf:item)*}) => {
@@ -114,6 +117,7 @@ macro_rules! __hyper__tm {
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! test_header {
     ($id:ident, $raw:expr) => {
@@ -154,6 +158,7 @@ macro_rules! test_header {
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! header {
     // $a:meta: Attributes associated with the header item (usually docs)

--- a/collector/benchmarks/script-servo/components/style/properties/properties.mako.rs
+++ b/collector/benchmarks/script-servo/components/style/properties/properties.mako.rs
@@ -3627,6 +3627,7 @@ impl AliasId {
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! css_properties_accessors {
     ($macro_name: ident) => {
@@ -3649,6 +3650,7 @@ macro_rules! css_properties_accessors {
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! longhand_properties_idents {
     ($macro_name: ident) => {

--- a/collector/benchmarks/script-servo/components/style_traits/values.rs
+++ b/collector/benchmarks/script-servo/components/style_traits/values.rs
@@ -71,6 +71,7 @@ where
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! serialize_function {
     ($dest: expr, $name: ident($( $arg: expr, )+)) => {
@@ -379,6 +380,7 @@ impl_to_css_for_predefined_type!(::cssparser::RGBA);
 impl_to_css_for_predefined_type!(::cssparser::Color);
 impl_to_css_for_predefined_type!(::cssparser::UnicodeRange);
 
+/// A macro.
 #[macro_export]
 macro_rules! define_css_keyword_enum {
     ($name: ident: values { $( $css: expr => $variant: ident),+, }
@@ -409,6 +411,7 @@ macro_rules! define_css_keyword_enum {
     };
 }
 
+/// A macro.
 #[cfg(feature = "servo")]
 #[macro_export]
 macro_rules! __define_css_keyword_enum__add_optional_traits {
@@ -422,6 +425,7 @@ macro_rules! __define_css_keyword_enum__add_optional_traits {
     };
 }
 
+/// A macro.
 #[cfg(not(feature = "servo"))]
 #[macro_export]
 macro_rules! __define_css_keyword_enum__add_optional_traits {
@@ -435,6 +439,7 @@ macro_rules! __define_css_keyword_enum__add_optional_traits {
     };
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! __define_css_keyword_enum__actual {
     ($name: ident [ $( $derived_trait: ident),* ]

--- a/collector/benchmarks/style-servo/components/style/gecko/generated/atom_macro.rs
+++ b/collector/benchmarks/style-servo/components/style/gecko/generated/atom_macro.rs
@@ -15534,6 +15534,7 @@ cfg_if! {
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! atom {
 ("") =>

--- a/collector/benchmarks/style-servo/components/style/gecko/regen_atoms.py
+++ b/collector/benchmarks/style-servo/components/style/gecko/regen_atoms.py
@@ -202,6 +202,7 @@ RULE_TEMPLATE = ('("{atom}") =>\n  '
                  ' }};')
 
 MACRO = '''
+/// A macro.
 #[macro_export]
 macro_rules! atom {{
 {}

--- a/collector/benchmarks/style-servo/components/style/gecko_string_cache/namespace.rs
+++ b/collector/benchmarks/style-servo/components/style/gecko_string_cache/namespace.rs
@@ -11,6 +11,7 @@ use std::fmt;
 use std::ops::Deref;
 use string_cache::{Atom, WeakAtom};
 
+/// A macro.
 #[macro_export]
 macro_rules! ns {
     () => { $crate::string_cache::Namespace(atom!("")) };

--- a/collector/benchmarks/style-servo/components/style/properties/properties.mako.rs
+++ b/collector/benchmarks/style-servo/components/style/properties/properties.mako.rs
@@ -50,6 +50,7 @@ use style_adjuster::StyleAdjuster;
 
 pub use self::declaration_block::*;
 
+/// A macro.
 #[cfg(feature = "gecko")]
 #[macro_export]
 macro_rules! property_name {
@@ -3593,6 +3594,7 @@ impl AliasId {
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! css_properties_accessors {
     ($macro_name: ident) => {
@@ -3615,6 +3617,7 @@ macro_rules! css_properties_accessors {
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! longhand_properties_idents {
     ($macro_name: ident) => {

--- a/collector/benchmarks/style-servo/components/style_traits/values.rs
+++ b/collector/benchmarks/style-servo/components/style_traits/values.rs
@@ -71,6 +71,7 @@ where
     }
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! serialize_function {
     ($dest: expr, $name: ident($( $arg: expr, )+)) => {
@@ -379,6 +380,7 @@ impl_to_css_for_predefined_type!(::cssparser::RGBA);
 impl_to_css_for_predefined_type!(::cssparser::Color);
 impl_to_css_for_predefined_type!(::cssparser::UnicodeRange);
 
+/// A macro.
 #[macro_export]
 macro_rules! define_css_keyword_enum {
     ($name: ident: values { $( $css: expr => $variant: ident),+, }
@@ -422,6 +424,7 @@ macro_rules! __define_css_keyword_enum__add_optional_traits {
     };
 }
 
+/// A macro.
 #[cfg(not(feature = "servo"))]
 #[macro_export]
 macro_rules! __define_css_keyword_enum__add_optional_traits {
@@ -435,6 +438,7 @@ macro_rules! __define_css_keyword_enum__add_optional_traits {
     };
 }
 
+/// A macro.
 #[macro_export]
 macro_rules! __define_css_keyword_enum__actual {
     ($name: ident [ $( $derived_trait: ident),* ]


### PR DESCRIPTION
The compiler must have got stricter about these recently.

This gets `futures`, `hyper`, and `style-servo` compiling again.
`script-servo` is still broken due to a different, trickier problem.