### PR TITLE
Add support for the new version of DHAT.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -234,26 +234,48 @@ except that `$PROFILER` is one of the following.
     text output is also written to files with a `clgann` prefix; this output is
     much the same as the `cgann`-prefixed files produced by Cachegrind, but
     with extra annotations showing function call counts.
-- `dhat`: Profile with [DHAT](http://valgrind.org/docs/manual/dh-manual.html),
-  a heap profiler.
-  - **Purpose**. DHAT is good for finding which parts of the code are causing a
-    lot of allocations. This is relevant if another profiler such as
+- `exp-dhat`: Profile with [ExpDHAT](http://valgrind.org/docs/manual/dh-manual.html),
+  an experimental heap profiler that came with Valgrind (`--tool=exp-dhat`)
+  prior to version 3.15.
+  - **Purpose**. ExpDHAT is good for finding which parts of the code are
+    causing a lot of allocations. This is relevant if another profiler such as
     `perf-record` or Cachegrind tell you that `malloc` and `free` are hot
     functions (as they often are).
   - **Slowdown**. Roughly 5--20x.
-  - **Prerequisites**. DHAT may require a rustc configured with `use-jemalloc =
-    false` to work well.
-  - **Configuration**. DHAT is configured within `profile` to run with the
-    non-default `--tot-blocks-allocd` option, so that it sorts its
-    output by the number of blocks allocated rather than the number of bytes
-    allocated. This is because the number of allocations typically has a
-    greater effect on speed than the size of those allocations; many small
-    allocations will typically be slower than a few large allocations.
+  - **Prerequisites**. ExpDHAT may require a rustc configured with
+    `use-jemalloc = false` to work well.
+  - **Configuration**. ExpDHAT is configured within `profile` to run with the
+    non-default `--tot-blocks-allocd` option, so that it sorts its output by
+    the number of blocks allocated rather than the number of bytes allocated.
+    This is because the number of allocations typically has a greater effect on
+    speed than the size of those allocations; many small allocations will
+    typically be slower than a few large allocations.
   - **Output**. Human-readable text output is written to files with a `dhat`
     prefix. This file includes summary statistics followed by numerous records,
     each of which aggregates data about all the allocations associated with a
     particular stack trace: the number of allocations, their average size, and
     how often they are read from and written to.
+- `dhat`: Profile with [DHAT](http://valgrind.org/docs/manual/dh-manual.html),
+  a heap profiler that comes with Valgrind (`--tool=dhat`) in versions 3.15
+  and later. It has the same purpose as ExpDHAT, but is significantly more
+  powerful.
+  - **Purpose**. DHAT is good for finding which parts of the code are causing a
+    lot of allocations. This is relevant if another profiler such as
+    `perf-record` or Cachegrind tell you that `malloc` and `free` are hot
+    functions (as they often are). It also gives insight into peak memory
+    usage, similar to Massif.
+  - **Slowdown**. Roughly 5--20x.
+  - **Prerequisites**. DHAT may require a rustc configured with `use-jemalloc =
+    false` to work well.
+  - **Configuration**. DHAT is configured within `profile` to run with the
+    non-default `--num-callers=4` option, which dictates stack depths. (This
+    value of 4 does not include inlined stack frames, so in practice the depths
+    of stack traces are a lot more than 4.) This is almost always enough, but
+    on the rare occasion it isn't, you can the value in `rustc-fake.rs` and
+    rebuild `collector`. Note that higher values make DHAT run more slowly and
+    increase the size of its data files.
+  - **Output**. Raw output is written to files with a `dhout` prefix. Those
+    files can be viewed with DHAT's viewer (`dh_view.html`).
 - `massif`: Profile with
   [Massif](http://valgrind.org/docs/manual/ms-manual.html), a heap profiler.
   - **Purpose**. Massif is designed to give insight into a program's peak

--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -92,7 +92,7 @@ fn main() {
                 assert!(cmd.status().expect("failed to spawn").success());
             }
 
-            "dhat" => {
+            "exp-dhat" => {
                 let mut cmd = Command::new("valgrind");
                 let has_valgrind = cmd.output().is_ok();
                 assert!(has_valgrind);
@@ -100,6 +100,19 @@ fn main() {
                     .arg("--show-top-n=500")
                     .arg("--num-callers=4")
                     .arg("--sort-by=tot-blocks-allocd")
+                    .arg(&rustc)
+                    .args(&args);
+
+                assert!(cmd.status().expect("failed to spawn").success());
+            }
+
+            "dhat" => {
+                let mut cmd = Command::new("valgrind");
+                let has_valgrind = cmd.output().is_ok();
+                assert!(has_valgrind);
+                cmd.arg("--tool=dhat")
+                    .arg("--num-callers=4")
+                    .arg("--dhat-out-file=dhout")
                     .arg(&rustc)
                     .args(&args);
 

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -387,7 +387,7 @@ fn main_result() -> Result<i32, Error> {
             'BaseIncr', 'CleanIncr', 'PatchedIncrs', 'All'")
            (@arg PROFILER: +required +takes_value
             "One of: 'time-passes', 'perf-record', 'cachegrind',\n\
-            'callgrind', 'dhat', 'massif', 'eprintln'")
+            'callgrind', 'exp-dhat', 'dhat', 'massif', 'eprintln'")
            (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
        )
        (@subcommand remove_benchmark =>


### PR DESCRIPTION
This requires renaming the support for the old version.