### PR TITLE
Fix `script-servo` bustage caused by the removal of `std::sync::mpsc::Select`.

### DIFF
--- a/collector/benchmarks/script-servo/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/collector/benchmarks/script-servo/components/script/dom/dedicatedworkerglobalscope.rs
@@ -39,7 +39,7 @@ use servo_url::ServoUrl;
 use std::mem::replace;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicBool;
-use std::sync::mpsc::{Receiver, RecvError, Select, Sender, channel};
+use std::sync::mpsc::{Receiver, RecvError, Sender, channel};
 use std::thread;
 use style::thread_state::{self, ThreadState};
 
@@ -277,6 +277,7 @@ impl DedicatedWorkerGlobalScope {
 
     #[allow(unsafe_code)]
     fn receive_event(&self) -> Result<MixedMessage, RecvError> {
+/*
         let scope = self.upcast::<WorkerGlobalScope>();
         let worker_port = &self.receiver;
         let timer_event_port = &self.timer_event_port;
@@ -303,6 +304,11 @@ impl DedicatedWorkerGlobalScope {
         } else {
             panic!("unexpected select result!")
         }
+*/
+        // `std::sync::mpsc::Select` was deprecated in Rust 1.36, so we just
+        // replaced this function's body with a panic. (That's good enough for
+        // a compile-time benchmark whose generated code is never run.)
+        panic!();
     }
 
     fn handle_script_event(&self, msg: WorkerScriptMsg) {

--- a/collector/benchmarks/script-servo/components/script/dom/serviceworkerglobalscope.rs
+++ b/collector/benchmarks/script-servo/components/script/dom/serviceworkerglobalscope.rs
@@ -29,7 +29,7 @@ use script_traits::{TimerEvent, WorkerGlobalScopeInit, ScopeThings, ServiceWorke
 use servo_config::prefs::PREFS;
 use servo_rand::random;
 use servo_url::ServoUrl;
-use std::sync::mpsc::{Receiver, RecvError, Select, Sender, channel};
+use std::sync::mpsc::{Receiver, RecvError, Sender, channel};
 use std::thread;
 use std::time::Duration;
 use style::thread_state::{self, ThreadState};
@@ -277,6 +277,7 @@ impl ServiceWorkerGlobalScope {
 
     #[allow(unsafe_code)]
     fn receive_event(&self) -> Result<MixedMessage, RecvError> {
+/*
         let scope = self.upcast::<WorkerGlobalScope>();
         let worker_port = &self.receiver;
         let devtools_port = scope.from_devtools_receiver();
@@ -304,6 +305,11 @@ impl ServiceWorkerGlobalScope {
         } else {
             panic!("unexpected select result!")
         }
+*/
+        // `std::sync::mpsc::Select` was deprecated in Rust 1.36, so we just
+        // replaced this function's body with a panic. (That's good enough for
+        // a compile-time benchmark whose generated code is never run.)
+        panic!();
     }
 
     pub fn script_chan(&self) -> Box<ScriptChan + Send> {

--- a/collector/benchmarks/script-servo/components/script/lib.rs
+++ b/collector/benchmarks/script-servo/components/script/lib.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(feature = "unstable", feature(core_intrinsics))]
 #![cfg_attr(feature = "unstable", feature(on_unimplemented))]
 #![feature(const_fn)]
-#![feature(mpsc_select)]
+//#![feature(mpsc_select)]
 #![feature(plugin)]
 
 #![deny(unsafe_code)]

--- a/collector/benchmarks/script-servo/components/script/script_thread.rs
+++ b/collector/benchmarks/script-servo/components/script/script_thread.rs
@@ -111,7 +111,7 @@ use std::ptr;
 use std::rc::Rc;
 use std::result::Result;
 use std::sync::Arc;
-use std::sync::mpsc::{Receiver, Select, Sender, channel};
+use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread;
 use style::thread_state::{self, ThreadState};
 use task_source::dom_manipulation::DOMManipulationTaskSource;
@@ -927,6 +927,7 @@ impl ScriptThread {
         // Receive at least one message so we don't spinloop.
         debug!("Waiting for event.");
         let mut event = {
+/*
             let sel = Select::new();
             let mut script_port = sel.handle(&self.port);
             let mut control_port = sel.handle(&self.control_port);
@@ -956,6 +957,11 @@ impl ScriptThread {
             } else {
                 panic!("unexpected select result")
             }
+*/
+            // `std::sync::mpsc::Select` was deprecated in Rust 1.36, so we
+            // just replaced this block with a panic. (That's good enough for a
+            // compile-time benchmark whose generated code is never run.)
+            panic!();
         };
         debug!("Got event.");
 

--- a/collector/benchmarks/script-servo/components/script/serviceworker_manager.rs
+++ b/collector/benchmarks/script-servo/components/script/serviceworker_manager.rs
@@ -188,10 +188,16 @@ impl ServiceWorkerManager {
     fn receive_message(&mut self) -> Result<Message, RecvError> {
         let msg_from_constellation = &self.own_port;
         let msg_from_resource = &self.resource_receiver;
+/*
         select! {
             msg = msg_from_constellation.recv() => msg.map(Message::FromConstellation),
             msg = msg_from_resource.recv() => msg.map(Message::FromResource)
         }
+*/
+        // `std::select` was deprecated in Rust 1.36, so we just replaced this
+        // occurrence with a panic. (That's good enough for a compile-time
+        // benchmark whose generated code is never run.)
+        panic!();
     }
 }
 


### PR DESCRIPTION
r? @Mark-Simulacrum 