### PR TITLE
make finish-message comparison link more like queued-message

### DIFF
--- a/site/src/server.rs
+++ b/site/src/server.rs
@@ -648,7 +648,7 @@ pub fn handle_collected(
                     .iter()
                     .find(|c| Some(&c.sha) == current_sha.as_ref())
                 {
-                    format!(": [comparison url]({})", try_commit.comparison_url())
+                    format!(", [comparison URL]({}).", try_commit.comparison_url())
                 } else {
                     String::new()
                 };


### PR DESCRIPTION
Currently it looks like
```
Success: Queued 2eefc6c with parent dc6db14, comparison URL.
```
and
```
Finished benchmarking try commit 2eefc6c: comparison url
```

This changes the latter to
```
Finished benchmarking try commit 2eefc6c, comparison URL.
```