### PR TITLE
Check for msgpack before using it

### DIFF
--- a/site/static/shared.js
+++ b/site/static/shared.js
@@ -222,6 +222,11 @@ function load_state(callback) {
 
 // This one is for making the request we send to the backend.
 function make_request(path, body) {
+    if(window.msgpack === undefined) {
+        alert("msgpack is not loaded, maybe allow scripts from cdnjs.cloudflare.com?");
+        return Promise.reject("msgpack is not loaded");
+    }
+
     return fetch(BASE_URL + path, {
         method: "POST",
         body: JSON.stringify(body),


### PR DESCRIPTION
When cdnjs.cloudflare.com is not allowed by noscript, the error handler
below would alert() the whole fetched data. Because that data is very
large, it can taken several seconds, before showing an alert. During
that time on Firefox for Android it is not possible to interact with
Firefox itself, so it is also not possible to open the noscript
settings to allow cdnjs.cloudflare.com.