### PR TITLE
mention that this contains the bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rust Compiler Performance Monitoring & Benchmarking
 
 This repository contains two primary crates: `collector` and `site`. Collector gathers data for each
-bors commit and the site displays the data.
+bors commit and the site displays the data and provides a GitHub bot for on-demand benchmarking.
 
 The primary required setup is to provide a folder with a `retries` file and a `times` folder. Data
 is gathered into https://github.com/rust-lang-nursery/rustc-timing by Rust Infrastructure; cloning

--- a/site/README.md
+++ b/site/README.md
@@ -5,6 +5,8 @@ This is the website for Rust compiler performance monitoring. The website
 contains a backend to process the raw data and expose it to the frontend,
 which displays graphs to the user.
 
+This also contains a GitHub bot to trigger on-demand benchmarking.
+
 https://github.com/rust-lang-nursery/rustc-timing contains the raw data
 from which rustc-perf pulls.
 


### PR DESCRIPTION
I had literally looked at this repo while searching for the bot, and discarded it because none of the docs mention the existence of a bot in this repo.