### PR TITLE
Bump team repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#43fac93c749056b2d22f5fa277d6efee202f12eb"
+source = "git+https://github.com/rust-lang/team#8d8902d7d4d3542f131f9dc7e7fde83732d92e88"
 dependencies = [
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This PR bumps the team repo to the latest commit. This is needed because a recent change in the repo added a new kind of team, and unfortunately the enum representing it was not exaustive. The bump both adds support for the new kind of team, and makes the enum not exaustive to avoid future issues like this.

r? @Mark-Simulacrum 