### PR TITLE
Fix "Total Time" tooltip to say "cpu-time" instead of "wall-time"

### DIFF
--- a/site/static/detailed-query.html
+++ b/site/static/detailed-query.html
@@ -177,7 +177,7 @@
                     let t = td(row, cur.percent_total_time.toFixed(2) + "%");
                     if (idx == 0) {
                         t.innerText += "*";
-                        t.setAttribute("title", "% of wall-time stat");
+                        t.setAttribute("title", "% of cpu-time stat");
                     }
                 }
                 if (prev) {


### PR DESCRIPTION
Fixes #528