### PR TITLE
Fix webrender-wrench incr-comp test.

### DIFF
--- a/collector/benchmarks/webrender-wrench/webrender/src/scene.rs
+++ b/collector/benchmarks/webrender-wrench/webrender/src/scene.rs
@@ -38,7 +38,6 @@ impl SceneProperties {
 
     /// Set the current property list for this display list.
     pub fn set_properties(&mut self, properties: DynamicProperties) {
-        println!("testing");
         self.pending_properties = Some(properties);
     }
 


### PR DESCRIPTION
This hopefully fixes the webrender-wrench error:
```
could not execute "patch" "-Np1" "-i" "0002-change-in-dependency.patch".
```

I accidentally checkin in a version of webrender with the patch in question already applied, so applying it again will bounce. 

r? @Mark-Simulacrum 