### PR TITLE
[perf] Avoid copying data on compare page unless it is really necessary

### DIFF
--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -115,15 +115,15 @@
         {
             let filter = document.querySelector("#filter").value;
             let test_names = unique([...Object.keys(data.a.data), ...Object.keys(data.b.data)]);
-            let isCopied = false
+            let is_copied = false;
             for (let name of test_names) {
                 if (!name.includes(filter)) {
-                    if(!isCopied){
+                    if (!is_copied) {
                         // Copying data is very expensive
                         // This branch ensures that we avoid copying
                         // if there are no filters (which is the most common case)
                         data = JSON.parse(JSON.stringify(DATA)); // deep copy
-                        isCopied = true
+                        is_copied = true;
                     }
                     delete data.a.data[name];
                     delete data.b.data[name];

--- a/site/static/compare.html
+++ b/site/static/compare.html
@@ -115,8 +115,16 @@
         {
             let filter = document.querySelector("#filter").value;
             let test_names = unique([...Object.keys(data.a.data), ...Object.keys(data.b.data)]);
+            let isCopied = false
             for (let name of test_names) {
                 if (!name.includes(filter)) {
+                    if(!isCopied){
+                        // Copying data is very expensive
+                        // This branch ensures that we avoid copying
+                        // if there are no filters (which is the most common case)
+                        data = JSON.parse(JSON.stringify(DATA)); // deep copy
+                        isCopied = true
+                    }
                     delete data.a.data[name];
                     delete data.b.data[name];
                 }
@@ -331,7 +339,6 @@
         }, state);
         make_request("/get", values).then(function(data) {
             DATA = data;
-            data = JSON.parse(JSON.stringify(DATA)); // deep copy
             populate_data(data);
         });
     }
@@ -350,8 +357,7 @@
     load_state(make_data);
 
     function rerender() {
-        let data = JSON.parse(JSON.stringify(DATA)); // deep copy
-        populate_data(data);
+        populate_data(DATA);
     }
 
     document.querySelector("#filter").addEventListener("change", rerender);


### PR DESCRIPTION
This saves about 700ms on initial load and all subsequent rerenders that have no filters (with the overhead of Chrome profiler).

The best way you can see it is by ticking checkboxes for individual runs (make sure filters are empty) It used to take about a second to rerender after ticking it, now it is almost instant.

There is definitely an opportunity to rewrite this without copying the data at all, which would speed up even filters, but this was literally the simplest low hanging fruit I could do at the moment.

Before:
![image](https://user-images.githubusercontent.com/25121817/73297500-f9213d00-420b-11ea-93e5-2b78835d461d.png)

After:
![image](https://user-images.githubusercontent.com/25121817/73297549-10602a80-420c-11ea-9966-c3920360d8fa.png)
