### PR TITLE
Add support for `-Zself-profile` to `collector profile`.

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -214,6 +214,18 @@ RUST_LOG=info ./target/release/collector --output-repo $OUTPUT_DIR \
 
 All the parts of this command are the same as for the `bench_local` subcommand,
 except that `$PROFILER` is one of the following.
+- `self-profile`: Profile with rustc's `-Zself-profile`.
+  - **Purpose**. This gives multiple high-level views of compiler performance,
+    in both tabular and graphical form.
+  - **Slowdown**. Minimal.
+  - **Output**. Raw output is written to a directory with a `Zsp` prefix.
+    The files in that directory can be processed with various
+    [`measureme`](https://github.com/rust-lang/measureme/) tools.
+    Human-readable output from `summarize` is written to a file with a
+    `summarize` prefix. Output from `flamegraph`, viewable with a web browser,
+    is written to a file with a `flamegraph` prefix. Output from `crox`,
+    viewable with Chromium's profiler, is written to a file with a `crox`
+    prefix.
 - `time-passes`: Profile with rustc's `-Ztime-passes`.
   - **Purpose**. This gives a high-level indication of compiler performance by
     showing how long each compilation pass takes.

--- a/collector/src/bin/rustc-fake.rs
+++ b/collector/src/bin/rustc-fake.rs
@@ -90,6 +90,13 @@ fn main() {
                 }
             }
 
+            "self-profile" => {
+                let mut cmd = Command::new(&rustc);
+                cmd.arg("-Zself-profile=Zsp").args(&args);
+
+                assert!(cmd.status().expect("failed to spawn").success());
+            }
+
             "time-passes" => {
                 let mut cmd = Command::new(&rustc);
                 cmd.arg("-Ztime-passes").args(&args);

--- a/collector/src/bin/rustc-perf-collector/main.rs
+++ b/collector/src/bin/rustc-perf-collector/main.rs
@@ -446,8 +446,8 @@ fn main_result() -> anyhow::Result<i32> {
             "One or more (comma-separated) of: 'Clean',\n\
             'BaseIncr', 'CleanIncr', 'PatchedIncrs', 'All'")
            (@arg PROFILER: +required +takes_value
-            "One of: 'time-passes', 'perf-record', 'cachegrind',\n\
-            'callgrind', ''dhat', 'massif', 'eprintln'")
+            "One of: 'self-profile', 'time-passes', 'perf-record',\n\
+            'cachegrind', 'callgrind', ''dhat', 'massif', 'eprintln'")
            (@arg ID: +required +takes_value "Identifier to associate benchmark results with")
        )
        (@subcommand remove_benchmark =>


### PR DESCRIPTION
It produces output for `summarize`, `flamegraph`, and `crox`.